### PR TITLE
Unify command line and configure file interfaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         run: pip install -r test_requirements.txt
 
       - name: Unittests
-        run: pytest
+        run: pytest -v
 
       - name: Lint
         run: black --diff --check --verbose .

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 dist/
 docs/_build/
 docs/fortls_changes.md
+
+.idea
+
+*.o
+*.mod
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info 
 dist/
 docs/_build/
+docs/fortls_changes.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Initialises the log channel and adds `$/setTrace` to override client's (i.e. VS Code) loglevel
 - Unified the interfaces from the command line and the configuration options file
   ([gnikit/fortls#17](https://github.com/gnikit/fortls/issues/17))
+- Updated the documentation and simplified the README.md
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.0
 
-### Adds
+### Added
 
 - Adds support for including preprocessor definitions from files same as `pp_defs`
 - Adds hover support for preprocessor variables
@@ -12,13 +12,13 @@
 - Adds `incl_suffixes` as a configuration option
 - Adds `EXTERNAL` as an attribute upon hover
 
-### Changes
+### Changed
 
 - Update constant parameters for `omp_lib` and `omp_lib_kinds` Interface v5.0
 - Format json files with `prettier`
 - Initialises the log channel and adds `$/setTrace` to override client's (i.e. VS Code) loglevel
 
-### Fixes
+### Fixed
 
 - Fixes the hover of preprocessor functions. It now displays the function name
   witout the argument list and the function body. The argument list cannot be
@@ -30,7 +30,7 @@
 
 ## 1.16.0
 
-### Adds
+### Added
 
 - Adds value for `PARAMETER` variables on hover
   ([#116](https://github.com/hansec/fortran-language-server/issues/116))
@@ -38,95 +38,95 @@
 
 ## 1.15.2
 
-### Fixes
+### Fixed
 
 - Further improves the literal variable hover added in v1.14.0
 
 ## 1.15.1
 
-### Fixes
+### Fixed
 
 - Fixes premature end of scope with variables named `end`
   ([gnikit/fortls#9](https://github.com/gnikit/fortls/issues/9))
 
 ## 1.15.0
 
-### Adds
+### Added
 
 - Adds `--config` option which allows arbitrary named configuration files
 
 ## 1.14.4
 
-### Fixes
+### Fixed
 
 - Fixes import host association includes (autocomplete work not complete)
   ([#187](https://github.com/hansec/fortran-language-server/issues/187))
 
 ## 1.14.3
 
-### Fixes
+### Fixed
 
 - Fixes parsing of `non_intrinsic` modules
   ([#206](https://github.com/hansec/fortran-language-server/issues/206))
 
 ## 1.14.2
 
-### Fixes
+### Fixed
 
 - Fixes error while parsing submodule parent name with spaces
   ([#207](https://github.com/hansec/fortran-language-server/issues/207))
 
 ## 1.14.1
 
-### Fixes
+### Fixed
 
 - Fixes language server features not triggering for variables in column 0
 
 ## 1.14.0
 
-### Fixes
+### Fixed
 
 - Fixes (partially) Fortran literal variable hover
   ([#188](https://github.com/hansec/fortran-language-server/issues/188))
 
 ## 1.13.0
 
-### Improvements
+### Added
 
 - Adds Python glob support for `excl_paths`, `source_dirs`, `include_dirs`
 
 ## 1.12.1
 
-### Fixes
+### Fixed
 
 - Fixes diagnostic error with interfaces as function arguments
   ([#200](https://github.com/hansec/fortran-language-server/issues/200))
 
 ## 1.12.0
 
-### Improvements
+### Changed
 
 - Add support for disabling diagnostics globally or on a per-project basis, ref [PR 163](https://github.com/hansec/fortran-language-server/pull/163)
 
-### Fixes
+### Fixed
 
 - Fix bug with enum declarations, fixes [#167](https://github.com/hansec/fortran-language-server/issues/167)
 - Fix typo in "ISHIFT" and "ISHIFTC" intrinsic functions, ref [PR 165](https://github.com/hansec/fortran-language-server/pull/165)
 
 ## 1.11.1
 
-### Fixes
+### Fixed
 
 - Fix bug with hover requests introduced in v1.11.0, fixes [#159](https://github.com/hansec/fortran-language-server/issues/159)
 
 ## 1.11.0
 
-### Improvements
+### Changed
 
 - Add support for specifying the language name returned for hover requests, ref [Fortran IntelliSense #17](https://github.com/hansec/vscode-fortran-ls/issues/17)
 - Add support for submodule implementations using the "PROCEDURE" keyword, fixes [#152](https://github.com/hansec/fortran-language-server/issues/152)
 
-### Fixes
+### Fixed
 
 - Fix bug with keywords in old style function declarations, fixes [#154](https://github.com/hansec/fortran-language-server/issues/154)
 - Fix bug when searching an empty scope, fixes [#151](https://github.com/hansec/fortran-language-server/issues/151)
@@ -135,18 +135,18 @@
 
 ## 1.10.3
 
-### Fixes
+### Fixed
 
 - Fix parsing bug with spaces in "old-style" kind specifications, fixes [#142](https://github.com/hansec/fortran-language-server/issues/142)
 - Fix issue with erroneous sub-word matching in preprocessor macro substitutions, fixes [#141](https://github.com/hansec/fortran-language-server/issues/141)
 
 ## 1.10.2
 
-### Improvements
+### Changed
 
 - Add support for "old-style" character length specification, fixes [#130](https://github.com/hansec/fortran-language-server/issues/130) and [#134](https://github.com/hansec/fortran-language-server/issues/134)
 
-### Fixes
+### Fixed
 
 - Fix "can't set attribute" error in USE traversal, fixes [#132](https://github.com/hansec/fortran-language-server/issues/132)
 - Fix bugs related to optional leading ampersands on continuation lines, fixes [#131](https://github.com/hansec/fortran-language-server/issues/131)
@@ -154,13 +154,13 @@
 
 ## 1.10.1
 
-### Fixes
+### Fixed
 
 - Fix bug in semicolon parsing, fixes [#127](https://github.com/hansec/fortran-language-server/issues/127)
 
 ## 1.10.0
 
-### Improvements
+### Changed
 
 - Initial implementation of preprocessor include file handling, ref [#115](https://github.com/hansec/fortran-language-server/issues/115)
 - Add support for specifying file suffixes for preprocessing, ref [#115](https://github.com/hansec/fortran-language-server/issues/115)
@@ -169,7 +169,7 @@
 - Add support for IMPURE keyword (contributed by @mcocdawc)
 - Improve readability by replacing various result arrays with namedtuples
 
-### Fixes
+### Fixed
 
 - Fix bug in open string literal detection, fixes [#124](https://github.com/hansec/fortran-language-server/issues/124)
 - Fix bug with multiline docstrings that start with a trailing comment, fixes [#118](https://github.com/hansec/fortran-language-server/issues/118)
@@ -181,13 +181,13 @@
 
 ## 1.9.1
 
-### Fixes
+### Fixed
 
 - Fix bug in USE ONLY accounting used for graph pruning, fixes [#122](https://github.com/hansec/fortran-language-server/issues/122)
 
 ## 1.9.0
 
-### Improvements
+### Changed
 
 - Add support for USE statement renaming requests, ref [#109](https://github.com/hansec/fortran-language-server/issues/109)
 - Add support for argument information in variable hover requests, fixes [#107](https://github.com/hansec/fortran-language-server/issues/107)
@@ -196,14 +196,14 @@
 - Reduce unnecessary parsing with single line file changes
 - Debugging: Add support for printing full result object
 
-### Fixes
+### Fixed
 
 - Remove required space between "DOUBLE PRECISION" and "DOUBLE COMPLEX" definitions, fixes [#110](https://github.com/hansec/fortran-language-server/issues/110)
 - Fix requests when a user-defined type variable has the same name as a defined type used in that scope
 
 ## 1.8.2
 
-### Fixes
+### Fixed
 
 - Fix parsing single line WHERE statements with trailing parentheses, fixes [#106](https://github.com/hansec/fortran-language-server/issues/106)
 - Fix erroneous object duplication diagnostics for DO, INTERFACE, etc. blocks
@@ -212,14 +212,14 @@
 
 ## 1.8.1
 
-### Fixes
+### Fixed
 
 - Fix bug with requests in lines with tab characters, fixes [#93](https://github.com/hansec/fortran-language-server/issues/93)
 - Fix bug with requests following "WRITE(\*,\*)" statements
 
 ## 1.8.0
 
-### Improvements
+### Changed
 
 - Add full support for ASSOCIATE statements, fixes [#101](https://github.com/hansec/fortran-language-server/issues/101)
 - Filter completion suggestions after "MODULE PROCEDURE" statements, fixes [#103](https://github.com/hansec/fortran-language-server/issues/103)
@@ -231,7 +231,7 @@
 
 ## 1.7.3
 
-### Fixes
+### Fixed
 
 - Fix case preservation in hover requests, fixes [#102](https://github.com/hansec/fortran-language-server/issues/102)
 - Fix rename requests for type-bound procedures without an explicit link statement (ie. "=>"), fixes [#104](https://github.com/hansec/fortran-language-server/issues/104)
@@ -241,20 +241,20 @@
 
 ## 1.7.2
 
-### Fixes
+### Fixed
 
 - Fix bug with definition/hover requests involving intrinsic functions/modules/variables (introduced in v1.7)
 
 ## 1.7.1
 
-### Fixes
+### Fixed
 
 - Fix bug with completion and signatureHelp requests on continuation lines (introduced in v1.7)
 - Fix out-of-range error with various requests on zero-length lines (introduced in v1.7)
 
 ## 1.7.0
 
-### Improvements
+### Changed
 
 - Add initial support for "textDocument/codeAction" requests, generate unimplemented deferred procedures
 - Show subroutine/function keywords ("PURE", "ELEMENTAL", etc.)
@@ -265,7 +265,7 @@
 - Command line options: Set number of threads used during initialization
 - Significant refactoring of core code
 
-### Fixes
+### Fixed
 
 - Fix "RecursionError" exception with circular user-defined type references, fixes [#100](https://github.com/hansec/fortran-language-server/issues/100)
 - Fix bug detecting TYPE definitions with an immediately following colon, ref [#100](https://github.com/hansec/fortran-language-server/issues/100)
@@ -273,7 +273,7 @@
 
 ## 1.6.0
 
-### Improvements
+### Changed
 
 - Add support for EXTERNAL subroutines
 - Diagnostics: Missing subroutine/function arguments and argument declarations
@@ -284,23 +284,23 @@
 
 ## 1.5.1
 
-### Improvements
+### Changed
 
 - Add support for semicolon separators and multiline preprocessor macros, fixes [#98](https://github.com/hansec/fortran-language-server/issues/98)
 - Add various "parsing errors" to debug_parser output
 
-### Fixes
+### Fixed
 
 - Use consistent file access method across debug_parser run and language server requests
 
 ## 1.5.0
 
-### Improvements
+### Changed
 
 - Add support for "textDocument/rename" requests
 - Add initial support for Doxygen and FORD style comment blocks, ref [#44](https://github.com/hansec/fortran-language-server/issues/44)
 
-### Fixes
+### Fixed
 
 - Fix language server crash with unknown user-defined type fields
 
@@ -310,12 +310,12 @@
 
 ## 1.4.0
 
-### Improvements
+### Changed
 
 - Add support for "textDocument/implementation" requests, ref [#94](https://github.com/hansec/fortran-language-server/issues/94)
 - Add option to preserve keyword ordering, ref [#97](https://github.com/hansec/fortran-language-server/issues/97)
 
-### Fixes
+### Fixed
 
 - Fix parsing bug with single line WHERE statements, fixes [#92](https://github.com/hansec/fortran-language-server/issues/92)
 - Fix bug with keyword parsing with nested parenthesis, fixes [#97](https://github.com/hansec/fortran-language-server/issues/97)
@@ -324,14 +324,14 @@
 
 ## 1.3.0
 
-### Improvements
+### Changed
 
 - Add support for user-defined type members in "textDocument/references" requests, fixes [#88](https://github.com/hansec/fortran-language-server/issues/88)
 - Link type-bound procedures with no explicit link to matching named scope in module, fixes [#89](https://github.com/hansec/fortran-language-server/issues/89)
 - Report diagnostics related to misplaced "CONTAINS" statements
 - Restructure README for improved clarity on capabilities/limitations
 
-### Fixes
+### Fixed
 
 - Fix bug with blank/empty lines in free-format continuations, fixes [#91](https://github.com/hansec/fortran-language-server/issues/91)
 - Fix exception in "textDocument/references" requests when no object is found, fixes [#86](https://github.com/hansec/fortran-language-server/issues/86)
@@ -339,43 +339,43 @@
 
 ## 1.2.1
 
-### Fixes
+### Fixed
 
 - Fix bug in nested user-defined type inheritance, fixes [#85](https://github.com/hansec/fortran-language-server/issues/85)
 - Fix bug in completion requests with empty parenthesis in request line
 
 ## 1.2.0
 
-### Improvements
+### Changed
 
 - Add support for local variables/objects in "textDocument/references" requests, ref [#84](https://github.com/hansec/fortran-language-server/issues/78)
 - Improve preprocessing to handle more types of conditional statements and macro substitution, ref [#78](https://github.com/hansec/fortran-language-server/issues/78)
 - Report diagnostics for excess "END" statements instead of causing parser failure, ref [#78](https://github.com/hansec/fortran-language-server/issues/78)
 
-### Fixes
+### Fixed
 
 - Fix missing "textDocument/references" results when line starts with target object, fixes [#84](https://github.com/hansec/fortran-language-server/issues/84)
 
 ## 1.1.1
 
-### Fixes
+### Fixed
 
 - Fix bug with backslash URI separators on Windows, fixes [#83](https://github.com/hansec/fortran-language-server/issues/83)
 
 ## 1.1.0
 
-### Improvements
+### Changed
 
 - Add initial implementation of simple preprocessor, ref [#78](https://github.com/hansec/fortran-language-server/issues/78)
 
-### Fixes
+### Fixed
 
 - Updated Fixed/Free detection logic using ampersands to check for comment line, fixes [#81](https://github.com/hansec/fortran-language-server/issues/81)
 - Support use of "END" as a variable, fixes [#82](https://github.com/hansec/fortran-language-server/issues/82)
 
 ## 1.0.5
 
-### Fixes
+### Fixed
 
 - Add support for named "SELECT" statements, fixes [#80](https://github.com/hansec/fortran-language-server/issues/80)
 - Track scopes for "ASSIGNMENT" and "OPERATOR" interface statements, fixes [#79](https://github.com/hansec/fortran-language-server/issues/79)
@@ -384,14 +384,14 @@
 
 ## 1.0.4
 
-### Fixes
+### Fixed
 
 - Normalize file paths when storing/accessing file index, fixes [#75](https://github.com/hansec/fortran-language-server/issues/75)
 - Fix intrinsic statement "COUNT" ([#76](https://github.com/hansec/fortran-language-server/pull/76))
 
 ## 1.0.3
 
-### Fixes
+### Fixed
 
 - Further improve discrimination between end statements and variables/block labels, ref [#73](https://github.com/hansec/fortran-language-server/issues/73)
 - Fix autocomplete errors when ASSOCIATE and ENUM statements are present
@@ -399,20 +399,20 @@
 
 ## 1.0.2
 
-### Fixes
+### Fixed
 
 - Fix discrimination between end statements and variables with underscores, fixes [#73](https://github.com/hansec/fortran-language-server/issues/73)
 - Detect enum definitions, fixes [#74](https://github.com/hansec/fortran-language-server/issues/74)
 
 ## 1.0.1
 
-### Fixes
+### Fixed
 
 - Detect and support associate statements, fixes [#72](https://github.com/hansec/fortran-language-server/issues/72)
 
 ## 1.0.0
 
-### Improvements
+### Changed
 
 - Add parsing of DO/IF/WHERE blocks and report scope end errors
 - Detect and report errors with invalid parent for scope definitions
@@ -420,7 +420,7 @@
 - Downgrade missing use warnings to information level
 - Add intrinsic declaration statement "double complex" ([#70](https://github.com/hansec/fortran-language-server/pull/70))
 
-### Fixes
+### Fixed
 
 - Fix bug with leading whitespace on visibility statements, fixes [#69](https://github.com/hansec/fortran-language-server/issues/69)
 - Fix parsing errors when "&" and "!" characters are present inside string literals
@@ -428,7 +428,7 @@
 
 ## 0.9.3
 
-### Fixes
+### Fixed
 
 - Fix detection of function definitions with leading module and variable statements, fixes [#66](https://github.com/hansec/fortran-language-server/issues/66)
 - Properly close remaining open scopes at end of file
@@ -436,22 +436,22 @@
 
 ## 0.9.2
 
-### Improvements
+### Changed
 
 - Improve handling of different file encodings, [PR #57](https://github.com/hansec/fortran-language-server/pull/57)
 
-### Fixes
+### Fixed
 
 - Fix autocomplete results for inherited members of user-defined types when the member type definition is only available in parent type's scope
 
 ## 0.9.1
 
-### Improvements
+### Changed
 
 - Add support for generic interfaces in type-bound procedures, [#64](https://github.com/hansec/fortran-language-server/issues/64)
 - Add parent scope information to masked variable errors, [#48](https://github.com/hansec/fortran-language-server/issues/48)
 
-### Fixes
+### Fixed
 
 - Fix parsing deferred length character definitions, [#61](https://github.com/hansec/fortran-language-server/issues/61)
 - Fix parsing function definitions with modifiers before type, [#63](https://github.com/hansec/fortran-language-server/issues/63)
@@ -459,12 +459,12 @@
 
 ## 0.9.0
 
-### Improvements
+### Changed
 
 - Add basic support for workspace/symbol requests
 - Add support for excluding source files based on a common suffix
 
-### Fixes
+### Fixed
 
 - Prevent detection of variables starting with "use" as USE statements, [#59](https://github.com/hansec/fortran-language-server/issues/59)
 - Improve parsing of USE ONLY statements, [#53](https://github.com/hansec/fortran-language-server/issues/53)
@@ -473,14 +473,14 @@
 
 ## 0.8.4
 
-### Fixes
+### Fixed
 
 - Check for existence of file during "textDocument/didClose" requests, [#46](https://github.com/hansec/fortran-language-server/issues/46)
 - Encode text as UTF-8 in change requests, fixes [#41](https://github.com/hansec/fortran-language-server/issues/41)
 
 ## 0.8.3
 
-### Improvements
+### Changed
 
 - Add support for generating debug logs
 - Add Fortran statements to autocomplete suggestions
@@ -488,19 +488,19 @@
 
 ## 0.8.2
 
-### Improvements
+### Changed
 
 - Add support for F03 style bracket array initialization, fixes [#35](https://github.com/hansec/fortran-language-server/issues/35)
 
 ## 0.8.1
 
-### Fixes
+### Fixed
 
 - Fix crash in completion requests with intrinsic modules
 
 ## 0.8.0
 
-### Improvements
+### Changed
 
 - Reformat completion information and snippets to match common language server conventions
 - Provide hover information for overloaded interfaces
@@ -509,33 +509,33 @@
 - Add support for arguments defined as interfaces in hover and signatureHelp requests
 - Unbetafy signatureHelp support
 
-### Fixes
+### Fixed
 
 - Fix linking type bound procedures with same name as subroutine/function definition
 
 ## 0.7.3
 
-### Fixes
+### Fixed
 
 - Improve detection of block statements, fixes [#32](https://github.com/hansec/fortran-language-server/issues/32)
 - Fix autocompletion with mixed case object definitions
 
 ## 0.7.2
 
-### Fixes
+### Fixed
 
 - Fix variable definition detection without spaces, fixes [#30](https://github.com/hansec/fortran-language-server/issues/30)
 
 ## 0.7.1
 
-### Improvements
+### Changed
 
 - Add option for displaying hover information for variables
 - Add subroutine/function keywords to hover information
 - Add more keywords to variable information
 - Support spaces between subroutine name and parentheses in signatureHelp
 
-### Fixes
+### Fixed
 
 - Fix bug with file paths that include spaces, fixes [#29](https://github.com/hansec/fortran-language-server/issues/29)
 - Fix bug where arguments were erroneously dropped for procedure variables
@@ -544,33 +544,33 @@
 
 ## 0.7.0
 
-### Improvements
+### Changed
 
 - Add support for signatureHelp requests with non-overloaded subroutines/functions
 - Provide autocomplete and hover information for procedures with explicit interface definitions
 - Add support for Fortran 2008 block constructs, fixes [#23](https://github.com/hansec/fortran-language-server/issues/23)
 - Add support for "DOUBLE COMPLEX" datatype
 
-### Fixes
+### Fixed
 
 - Fix bug where external interfaces were erroneously public in default private modules
 - Fix bug producing repeated objects with include statements
 
 ## 0.6.2
 
-### Improvements
+### Changed
 
 - Catch and report more types of errors related to file processing, fixes [#21](https://github.com/hansec/fortran-language-server/issues/21)
 
 ## 0.6.1
 
-### Fixes
+### Fixed
 
 - Fix bug with incremental sync using VSCode on windows, fixes [#20](https://github.com/hansec/fortran-language-server/issues/20)
 
 ## 0.6.0
 
-### Improvements
+### Changed
 
 - Add keywords to autocomplete results in variable definition statements
 - Filter autocompletion results in extend, import, and procedure statements
@@ -579,7 +579,7 @@
 - Ignore autocomplete and definition requests on preprocessor lines
 - Add option to test completion and definition requests in debug mode
 
-### Fixes
+### Fixed
 
 - Improve export of abstract and external interfaces for completion and definition requests
 - Fix scope name detection to prevent confusing variables that start with Fortran statement names
@@ -589,25 +589,25 @@
 
 ## 0.5.0
 
-### Improvements
+### Changed
 
 - Add intrinsic functions and modules to autocomplete suggestions
 - Add support for include statements
 
-### Fixes
+### Fixed
 
 - Remove erroneously included global objects from autocomplete results in USE ONLY statements
 - Fix displayed type for derived type objects in autocomplete requests
 
 ## 0.4.0
 
-### Improvements
+### Changed
 
 - Add support for find_references, global and top-level module objects only
 - Filter autocomplete suggestions for callable objects in call statements
 - Speedup initialization and updates on large projects by accelerating construction of USE tree
 
-### Fixes
+### Fixed
 
 - Fix parser error with definitions requiring enclosing scopes in #include files and unnamed programs, fixes [#17](https://github.com/hansec/fortran-language-server/issues/17)
 - Fix parser failure with visibility statements in included fortran files, fixes [#16](https://github.com/hansec/fortran-language-server/issues/16)
@@ -615,38 +615,38 @@
 
 ## 0.3.7
 
-### Improvements
+### Changed
 
 - Automatically trigger autocomplete on `%` character
 - Show named interfaces and prototypes in document outline
 - Add support for autocomplete without prefix filtering
 
-### Fixes
+### Fixed
 
 - Fix occasional language server error in autocompletion with class methods
 
 ## 0.3.6
 
-### Improvements
+### Changed
 
 - Add support for fortran submodules, fixes [#14](https://github.com/hansec/fortran-language-server/issues/14) and [#15](https://github.com/hansec/fortran-language-server/issues/15)
 - Improve line tokenization and parsing
 
-### Fixes
+### Fixed
 
 - Fix parsing errors with incomplete function definitions
 - Fix bugs in symbol and parser debugging
 
 ## 0.3.5
 
-### Fixes
+### Fixed
 
 - Improve unicode file handling with Python 3.x
 - Add support for unnamed programs, fixes [#13](https://github.com/hansec/fortran-language-server/issues/13)
 
 ## 0.3.4
 
-### Fixes
+### Fixed
 
 - Fix parser error with uppercase characters in scope names, fixes [#11](https://github.com/hansec/fortran-language-server/issues/11)
 - Add support for object names with a leading underscore, fixes [#9](https://github.com/hansec/fortran-language-server/issues/9)
@@ -654,13 +654,13 @@
 
 ## 0.3.3
 
-### Improvements
+### Changed
 
 - Improved Windows support and added AppVeyor CI testing
 - Add support for snippets in autocompletion
 - Ignore requests in comment sections
 
-### Fixes
+### Fixed
 
 - Fix bug with string/byte handling in Python 3
 - Fix bug with multiprocess support on Windows
@@ -668,7 +668,7 @@
 
 ## 0.3.2
 
-### Fixes
+### Fixed
 
 - Fix parsing variable definitions containing separators inside strings, fixes [#4](https://github.com/hansec/fortran-language-server/issues/4)
 - Fix incorrect variable masking error in functions, fixes [#5](https://github.com/hansec/fortran-language-server/issues/5)
@@ -676,25 +676,25 @@
 
 ## 0.3.1
 
-### Improvements
+### Changed
 
 - Do not show warnings for variable masking in interface definitions
 - Respect visibility statements when searching for object in scope
 
-### Fixes
+### Fixed
 
 - Fix bug in incremental document sync with ending newline
 
 ## 0.3.0
 
-### Improvements
+### Changed
 
 - Add basic file diagnostics (double declaration, variable masking, unknown USE)
 - Indicate optional arguments in autocomplete suggestions
 - Detect source code format from file contents instead of extension
 - Add support for incremental document synchronization
 
-### Fixes
+### Fixed
 
 - Fix parsing error when variable definition line is incomplete
 - Fix incorrect line handling with open parentheses
@@ -702,7 +702,7 @@
 
 ## 0.2.0
 
-### Improvements
+### Changed
 
 - Add support for recursive directory inclusion from "root_path"
 - Provide option to skip type members in documentSymbol requests
@@ -710,32 +710,32 @@
 - Filter interface suggestions to only show unique signatures
 - Link imported procedures in interface definitions
 
-### Fixes
+### Fixed
 
 - Fix line continuation handling for free form files with trailing and leading ampersands
 - Improve parentheses matching in line parsing
 
 ## 0.1.4
 
-### Improvements
+### Changed
 
 - Handle line continuations in language server requests
 - Add server version number to help output
 
-### Fixes
+### Fixed
 
 - Fix bug when parsing files with unicode characters
 
 ## 0.1.3
 
-### Improvements
+### Changed
 
 - Include interfaces in autocomplete suggestions
 - Restrict autocomplete suggestions by object visibility
 - Improve USE statement traversal
 - Add notifications for parser failures
 
-### Fixes
+### Fixed
 
 - Fix bug where parsing errors during workspace initialization could crash the language server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
   ([#169](https://github.com/hansec/fortran-language-server/issues/169))
 - Fixes include with external files
   ([gnikit/fortls#13](https://github.com/gnikit/fortls/issues/13))
+- `POINTER` attribute now displays upon hover
+  ([gnikit/fortls#16](https://github.com/gnikit/fortls/issues/16))
 
 ## 1.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
   ([gnikit/fortls#13](https://github.com/gnikit/fortls/issues/13))
 - `POINTER` attribute now displays upon hover
   ([gnikit/fortls#16](https://github.com/gnikit/fortls/issues/16))
+- Fixes `END FORALL` end of scope error
+  ([gnikit/fortls#18](https://github.com/gnikit/fortls/issues/18))
 
 ## 1.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 - Update constant parameters for `omp_lib` and `omp_lib_kinds` Interface v5.0
 - Format json files with `prettier`
 - Initialises the log channel and adds `$/setTrace` to override client's (i.e. VS Code) loglevel
+- Unified the interfaces from the command line and the configuration options file
+  ([gnikit/fortls#17](https://github.com/gnikit/fortls/issues/17))
+
+### Deprecated
+
+- Option `--preserve_keyword_order` has been substituted with its opposite `--sort_keywords`
 
 ### Fixed
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,30 @@
+fortls
+
+The MIT License (MIT)
+
+Copyright 2021-2022 Giannis Nikiteas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+fortran-language-server
+
 The MIT License (MIT)
 
 Copyright 2017-2019 Chris Hansen

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # fortls - the Fortran Language Server
 
 [![PyPI Latest Release](https://img.shields.io/pypi/v/fortls.svg)](https://pypi.org/project/fortls/)
-[![Tests](https://github.com/gnikit/fortran-language-server/actions/workflows/main.yml/badge.svg)](https://github.com/gnikit/fortran-language-server/actions/workflows/main.yml)
+[![Tests](https://github.com/gnikit/fortls/actions/workflows/main.yml/badge.svg)](https://github.com/gnikit/fortls/actions/workflows/main.yml)
 [![Documentation](https://github.com/gnikit/fortls/actions/workflows/docs.yml/badge.svg)](https://github.com/gnikit/fortls/actions/workflows/docs.yml)
-[![image](https://img.shields.io/github/license/gnikit/fortran-language-server.svg)](https://github.com/gnikit/fortran-language-server/blob/master/LICENSE)
+[![image](https://img.shields.io/github/license/gnikit/fortls.svg)](https://github.com/gnikit/fortls/blob/master/LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 `fortls` is an implementation of the [Language Server Protocol](https://github.com/Microsoft/language-server-protocol)
@@ -23,6 +23,9 @@ This project is based on @hansec's original Language Server implementation but t
 `fortls` (this project) is now developed independently of the upstream `hansec/fortran-language-server` project and contains numerous bug fixes and new features
 the original `fortran-language-server` does not.
 
+For a complete and detailed list of the differences between the two Language Servers
+see the Documentation section: [Unique fortls features (not in fortran-language-server)](https://gnikit.github.io/fortls/fortls_changes.html)
+
 The name of executable for this project has been chosen to remain `fortls`
 to allow for integration with pre-existing plugins and workflows but it is
 potentially subject to change.
@@ -32,7 +35,7 @@ potentially subject to change.
 - Project-wide and Document symbol detection and Renaming
 - Hover support, Signature help and Auto-completion
 - GoTo/Peek implementation and Find/Peek references
-- Symbol renaming (`textDocument/rename`)
+- Preprocessor support
 - Documentation parsing ([Doxygen](http://www.doxygen.org/) and
   [FORD](https://github.com/Fortran-FOSS-Programmers/ford) styles)
 - Access to multiple intrinsic modules and functions
@@ -61,7 +64,6 @@ potentially subject to change.
 
 - Signature help is not available for overloaded subroutines/functions
 - Diagnostics are only updated when files are saved or opened/closed
-- Files included for preprocessor are not parsed for Fortran objects
 
 ## Installation
 
@@ -71,215 +73,27 @@ pip install fortls
 
 ## Settings
 
-The following global settings can be used when launching the language
-server.
+`fortls` can be configured through both the command line e.g.
+`fortls --hover_signature` or through a Configuration json file.
+The two interfaces are identical and a full list of the available options can
+be found in the [Documentation](https://gnikit.github.io/fortls/options.html)
+or through `fortls -h`
 
-- `--config` Configuration options file (default: `.fortls`)
-- `--nthreads` Number of threads to use during workspace
-  initialization (default: 4)
-- `--notify_init` Send notification message when workspace
-  initialization is complete
-- `--symbol_skip_mem` Do not include type members in document symbol
-  results
-- `--incremental_sync` Use incremental document synchronization
-- `--autocomplete_no_prefix` Do not filter autocomplete results by
-  variable prefix
-- `--autocomplete_no_snippets` Do not use snippets with place holders
-  in autocomplete results
-- `--autocomplete_name_only` Complete only the name of procedures and
-  not the parameters
-- `--lowercase_intrinsics` Use lowercase for intrinsics and keywords
-  in autocomplete requests
-- `--use_signature_help` Use signature help instead of snippets for
-  subroutines/functions
-- `--variable_hover` Show hover information for variables (default:
-  subroutines/functions only)
-- `--hover_signature` Show signature information in hover for argument
-  (also enables '--variable_hover')
-- `--preserve_keyword_order` Display variable keywords information in
-  original order (default: sort to consistent ordering)
-- `--enable_code_actions` Enable experimental code actions (default:
-  false)
-- `--disable_diagnostics` Disable code diagnostics (default: false)
-- `--max_line_length` Maximum line length (default: none)
-- `--max_comment_line_length` Maximum comment line length (default:
-  none)
-- `--debug_log` Write debug information to `root_dir/fortls_debug.log`
-  (requires a specified `root_dir` during initialization)
-
-### Debug settings
-
-The following settings can be used to perform [standalone debug
-tests](https://github.com/hansec/fortran-language-server/wiki) on the
-fortls
-
-- `--debug_filepath=DEBUG_FILEPATH` File path for fortls tests
-- `--debug_rootpath=DEBUG_ROOTPATH` Root path for fortls tests
-- `--debug_line=DEBUG_LINE` Line position for fortls (1-indexed)
-- `--debug_char=DEBUG_CHAR` Character position for fortls tests (1-indexed)
-- `--debug_full_result` Print full result object instead of condensed
-  version
-- `--debug_parser` Test source code parser on specified file
-- `--debug_diagnostics` Test diagnostic notifications for specified
-  file
-- `--debug_symbols` Test symbol request for specified file
-- `--debug_workspace_symbols=QUERY_STRING` Test workspace/symbol
-  request for project-wide search
-- `--debug_completion` Test completion request for specified file and
-  position
-- `--debug_signature` Test signatureHelp request for specified file
-  and position
-- `--debug_definition` Test definition request for specified file and
-  position
-- `--debug_hover` Test hover request for specified file and position
-- `--debug_implementation` Test implementation request for specified
-  file and position
-- `--debug_references` Test references request for specified file and
-  position
-- `--debug_rename=RENAME_STRING` Test rename request for specified
-  file and position
-- `--debug_actions` Test codeAction request for specified file and
-  position
-
-## Configuration
-
-Project specific settings can be specified by creating a **options** JSON file.
-You can specify the location and name of the file with the `--config` option.
-By default the options file is assumed to be `root_dir` with the name `.fortls`.
-
-All command line options are also available through the **options** file as well.
-
-- `lowercase_intrinsics` Use lowercase for intrinsics and keywords in
-  autocomplete requests (default: false)
-- `debug_log` Write debug information to `root_dir/fortls_debug.log`
-  (default: false)
-- `disable_diagnostics` Disable diagnostics for this project only
-  (default: false)
-- `max_line_length` Maximum line length (default: none)
-- `max_comment_line_length` Maximum comment line length (default:
-  none)
-- `incl_suffixes` Add more Fortran extensions to be parsed by the server
-
-## Additional settings
-
-### Default file extensions
-
-By default all files with the suffix `F,F77,F90,F95,F03,F08,FOR,FPP`
-(case-insensitive) in the `root_dir` directory, specified during
-initialization, and all its sub-directories are parsed and included in
-the project.
-
-### Excluding folders and file extensions
-
-Directories and files can be excluded from the project by specifying
-their paths in the `excl_paths` variable in the options file.
-Paths can be absolute or relative to `root_dir`.
-
-Excluded directories **will not** exclude all sub-directories.
-Source files with a common suffix may also be excluded using the
-`excl_suffixes` variable.
-
-> NOTE: All directory inputs fields (`excl_paths`, `source_dirs`, `include_dirs`) support
-> [Python glob patterns](https://docs.python.org/3/library/glob.html) e.g. `/**`, `*`, etc.
-
-### Including source directories
-
-By default all source directories under `root_dir` are recursively included.
-Source file directories can also be specified manually by specifying
-their paths in the `source_dirs` variable in the configuration options file.
-Paths can be absolute or relative to `root_dir`.
-`root_dir` does not need to be specified manually as it is always included.
-
-When defining `source_dirs` in the configuration options filethe default behaviour (i.e. including
-all files in all subdirectories under `root_dir`) is overriden. To include them
-back again one can do
+An example for a Configuration file is given below
 
 ```json
 {
-  "source_dirs": ["/**", "all", "other", "dirs"]
-}
-```
-
-### Preprocessing
-
-**Note:** Preprocessor support is not "complete", see below. For
-preprocessed files the `fortls` will only analyze code within
-preprocessor conditional regions if the conditional test can be
-evaluated by the server or if the region is the _default_ path (ie. a
-bare `#else` region).
-
-**Note:** Currently, `#include` statements are only used for
-preprocessing (ie. tracking definitions). Fortran objects defined in
-these files will not be processed.
-
-File suffixes for preprocessing can be controlled with the variable
-`pp_suffixes` in a workspace's configuration options file. When this variable is
-used _only_ those files with the specified suffixes will be
-preprocessed. If an empty array is specified then _no_ preprocessing
-will be performed on any files. By default, or if the variable is
-omitted or `null`, only files with upper case suffixes are preprocessed.
-
-Preprocessor definitions can be set for each project, to improve support
-for Fortran files using conditional compilation, using the `pp_defs`
-variable in the configuration options file. Preprocessing is performed _only_ for
-files where the file extension is all caps (ie. ".F90", ".F", etc.).
-Currently, support for preprocessing is limited to variables declared in
-the project's configuration options file or in the source file of interest as
-`#include` files and inheritance through `USE` statements are yet not
-supported. Variable substitution is also performed within files, but is
-currently limited to non-recursive cases. For example, `#define PP_VAR1 PP_VAR2` will cause `PP_VAR1` to be replaced with the text `PP_VAR2`
-throughout the file, not that value of `PP_VAR2`.
-
-Include directories can be specified using the variable `include_dirs`
-in a workspace's configuration options file. These directories are _only_ used to
-search for preprocessor `#include`'d files. The directory containing the
-file where an `#include` statement is encountered is always searched.
-File search is performed starting with the containing directory followed
-by the specified `include_dirs` specified paths, in order (left to
-right).
-
-```json
-{
-  "source_dirs": ["subdir1/**", "subdir2"],
-  "excl_paths": ["subdir3/**", "subdir1/file_to_skip.F90"],
+  "incremental_sync": true,
+  "lowercase_intrinsics": true,
+  "hover_signature": true,
+  "use_signature_help": true,
+  "excl_paths": ["tests/**", "tools/**"],
   "excl_suffixes": ["_skip.f90"],
-  "pp_suffixes": [".f03", ".F90"],
-  "pp_defs": { "HAVE_PACKAGE": "" },
-  "include_dirs": ["rel_include/dir_path", "/abs/include/dir/path"],
-  "lowercase_intrinsics": false,
-  "debug_log": false
+  "include_dirs": ["include/**"],
+  "pp_suffixes": [".F90", ".h"],
+  "pp_defs": { "HAVE_HDF5": "", "MPI_Comm": "integer" }
 }
 ```
-
-<!-- ## Editor examples (Atom)
-
-Document symbols (`textDocument/documentSymbol`):
-
-![image](https://raw.githubusercontent.com/gnikit/fortran-language-server/master/images/fortls_outline.png)
-
-Auto-complete (`textDocument/completion`):
-
-![image](https://raw.githubusercontent.com/gnikit/fortran-language-server/master/images/fortls_autocomplete.gif)
-
-Signature help (`textDocument/signatureHelp`):
-
-![image](https://raw.githubusercontent.com/gnikit/fortran-language-server/master/images/fortls_sigHelp.gif)
-
-Goto definition (`textDocument/definition`):
-
-![image](https://raw.githubusercontent.com/gnikit/fortran-language-server/master/images/fortls_gotodef.gif)
-
-Hover (`textDocument/hover`):
-
-![image](https://raw.githubusercontent.com/gnikit/fortran-language-server/master/images/fortls_hover.gif)
-
-Find references (`textDocument/references`):
-
-![image](https://raw.githubusercontent.com/gnikit/fortran-language-server/master/images/fortls_refs.png)
-
-Diagnostics:
-
-![image](https://raw.githubusercontent.com/gnikit/fortran-language-server/master/images/fortls_diag.png) -->
 
 ## Implemented server requests
 
@@ -310,9 +124,9 @@ Support the original project go [here](https://paypal.me/hansec)
 
 ## Bug reports
 
-When [filing bugs](https://github.com/gnikit/fortran-language-server/issues/new)
+When [filing bugs](https://github.com/gnikit/fortls/issues/new)
 please provide example code to reproduce the observed issue.
 
 ## License
 
-This project is made available under the [MIT License](https://github.com/gnikit/fortran-language-server/blob/master/LICENSE).
+This project is made available under the [MIT License](https://github.com/gnikit/fortls/blob/dev/LICENSE).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,40 @@ import sys
 
 sys.path.insert(0, os.path.abspath(".."))
 
+# Generate the agglomerated changes (from the CHANGELOG) between fortls
+# and the fortran-language-server project
+with open("../CHANGELOG.md", "r") as f:
+    lns = f.readlines()
+
+lns = lns[0 : lns.index("## 1.12.0\n")]
+changes = {
+    "Added": [],
+    "Changed": [],
+    "Deprecated": [],
+    "Removed": [],
+    "Fixed": [],
+    "Security": [],
+}
+
+field = ""
+for i in lns:
+    if i.startswith("## "):
+        continue
+    if i.startswith("### "):
+        field = i[4:-1]
+        continue
+    if i.startswith("- ") or i.startswith("  "):
+        changes[field].append(i)
+
+new_file = ["# Unique fortls features (not in fortran-language-server)\n"]
+for key, val in changes.items():
+    if val:
+        new_file.append(f"\n## {key}\n\n")
+        new_file.extend(val)
+
+with open("fortls_changes.md", "w") as f:
+    f.writelines(new_file)
+
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,7 @@ release = "1.16.0"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    "sphinxarg.ext",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.autosummary",

--- a/docs/fortls.rst
+++ b/docs/fortls.rst
@@ -20,6 +20,14 @@ fortls.helper\_functions module
    :undoc-members:
    :show-inheritance:
 
+fortls.interface module
+-----------------------
+
+.. automodule:: fortls.interface
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 fortls.intrinsics module
 ------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ fortls
    :caption: Contents:
 
    README.md
+   options.rst
    fortls_changes.md
    modules.rst
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ fortls
    :caption: Contents:
 
    README.md
+   fortls_changes.md
    modules.rst
 
 ..

--- a/docs/options.rst
+++ b/docs/options.rst
@@ -1,0 +1,215 @@
+Configuration options
+=====================
+
+``fortls`` can be configured through the command line interface and/or
+through a configuration file (by default named ``.fortls``).
+The options available from the command line and through the configuration file
+are identical and interchangeable.
+
+.. note:: Options defined in the configuration file have precedence over command line arguments.
+
+The following sections discuss the available settings in detail.
+
+
+.. _cmd_interface:
+
+Configuration using the command line
+------------------------------------
+
+.. argparse::
+   :module: fortls
+   :func: commandline_args
+   :prog: fortls
+   :nodefault:
+
+Configuration using a file
+--------------------------
+
+A configuration file is a JSON style file that contains project specific
+settings for ``fortls``. By default the name of the filepath is assumed to be
+``root_path/.fortls`` but different files can be used through the command line
+interface e.g. ``fortls --config my_project.json``.
+
+The settings that can be specified in the configuration file are identical to
+the ones available through the command line interface having removed the leading
+``--`` characters. For the command line interface see :ref:`cmd_interface`.
+
+Available options
+#################
+
+All the ``fortls`` settings with their default arguments can be found below
+
+.. code-block:: json
+
+   {
+      "nthreads": 4,
+      "notify_init": false,
+      "incremental_sync": false,
+      "sort_keywords": false,
+      "debug_log": false,
+
+      "source_dirs": ["./**"],
+      "incl_suffixes": [],
+      "excl_suffixes": [],
+      "excl_paths": [],
+
+      "autocomplete_no_prefix": false,
+      "autocomplete_no_snippets": false,
+      "autocomplete_name_only": false,
+      "lowercase_intrinsics": false,
+      "use_signature_help": false,
+
+      "variable_hover": false,
+      "hover_signature": false,
+      "hover_language": "fortran90",
+
+      "max_line_length": -1,
+      "max_comment_line_length": -1,
+      "disable_diagnostics": false,
+
+      "pp_suffixes": [],
+      "include_dirs": [],
+      "pp_defs": {},
+
+      "symbol_skip_mem": false,
+
+      "enable_code_actions": false
+   }
+
+Sources file parsing
+####################
+
+source_dirs
+***********
+
+.. code-block:: json
+
+   "source_dirs": ["./**", "/external/fortran/src"]
+
+By default all directories under the current project will be recursively parsed
+for Fortran sources. Alternatively, one can define a series of directories
+for ``fortls`` to look for source files
+
+.. note:: glob fnmatch style patterns  are allowed
+
+incl_suffixes
+*************
+
+.. code-block:: json
+
+   "incl_suffixes": [".h", ".FYP"]
+
+``fortls`` will parse only files with ``incl_suffixes`` extensions found in
+``source_dirs``. By default ``incl_suffixes`` are defined as
+.F .f .F03 .f03 .F05 .f05 .F08 .f08 .F18 .f18 .F77 .f77 .F90 .f90 .F95 .f95 .FOR .for .FPP .fpp.
+Additional source file extensions can be defined in ``incl_suffixes``.
+
+.. note:: The default file extensions cannot be overwritten. ``incl_suffixes`` will only append to the default extensions. 
+
+
+excl_suffixes
+*************
+
+.. code-block:: json
+
+   "excl_suffixes": ["_tmp.f90", "_hdf5.F90"]
+
+If certain files or suffixes do not need to be parsed these can be excluded by
+deffining ``excl_suffixes``
+
+
+excl_paths
+**********
+
+Entire directories can be excluded from parsing by including them in ``excl_paths``.
+
+.. note:: glob fnmatch style patterns  are allowed
+
+``excl_paths`` uses glob patterns so if you want to exclude a directory and all
+its subdirectories from being parsed you should define it like so
+
+.. code-block:: json
+
+   "excl_paths": ["exclude_dir/**"]
+
+
+Preprocessor
+############
+
+pp_suffixes
+***********
+
+.. code-block:: json
+
+   "pp_suffixes" : [".h", ".F90", ".fpp"]
+
+By default preprocessor definitions are parsed for all Fortran source files
+with uppercase extensions e.g. ``.F90``, ``.F``, ``.F08``, etc.. However, the
+default behaviour can be overriden by defining ``pp_defs``.
+
+
+include_dirs
+************
+
+.. code-block:: json
+
+   "include_dirs": ["include", "preprocessor", "/usr/include"]
+
+By default ``fortls`` will scan the project's directories for files with extensions
+``PP_SUFFIXES`` to parse for **preprocessor definitions**. However, if the preprocessor
+files are external to the project, their locations can be specific via
+``include_dirs``.
+
+.. note:: glob fnmatch style patterns  are allowed
+.. warning:: Source files detected in ``include_dirs`` will not be parsed for Fortran objects unless they are also included in ``source_dirs``.
+
+
+pp_defs
+*******
+
+.. code-block:: json
+
+   "pp_defs": {
+      "HAVE_PETSC": ""
+      "Mat": "type(tMat)"
+   }
+
+Additional **preprocessor definitions** from what are specified in files found in 
+``include_dirs`` can be defined in ``pp_defs``.
+
+.. note:: Definitions in ``pp_defs`` will override definitions from ``include_dirs``
+
+
+Limitations
+***********
+
+- Recursive substitution is not available e.g.
+
+   .. code-block:: cpp
+
+      #define VAR1 10
+      #define VAR2 VAR1
+
+
+Debug Options (command line only)
+---------------------------------
+
+Options for debugging language server
+
+-  ``--debug_filepath DEBUG_FILEPATH``         File path for language server tests
+-  ``--debug_rootpath DEBUG_ROOTPATH``         Root path for language server tests
+-  ``--debug_parser``                          Test source code parser on specified file
+-  ``--debug_hover``                           Test `textDocument/hover` request for specified file and position
+-  ``--debug_rename RENAME_STRING``            Test `textDocument/rename` request for specified file and position
+-  ``--debug_actions``                         Test `textDocument/codeAction` request for specified file and position
+-  ``--debug_symbols``                         Test `textDocument/documentSymbol` request for specified file
+-  ``--debug_completion``                      Test `textDocument/completion` request for specified file and position
+-  ``--debug_signature``                       Test `textDocument/signatureHelp` request for specified file and position
+-  ``--debug_definition``                      Test `textDocument/definition` request for specified file and position
+-  ``--debug_references``                      Test `textDocument/references` request for specified file and position
+-  ``--debug_diagnostics``                     Test diagnostic notifications for specified file
+-  ``--debug_implementation``                  Test `textDocument/implementation` request for specified file and position
+-  ``--debug_workspace_symbols QUERY_STRING``  Test `workspace/symbol` request
+-  ``--debug_line INTEGER``                    Line position for language server tests (1-indexed)
+-  ``--debug_char INTEGER``                    Character position for language server tests (1-indexed)
+-  ``--debug_full_result``                     Print full result object instead of condensed version

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ sphinx
 sphinx_autodoc_typehints
 sphinx_rtd_theme
 sphinxprettysearchresults
+sphinx-argparse

--- a/fortls/helper_functions.py
+++ b/fortls/helper_functions.py
@@ -319,7 +319,8 @@ def map_keywords(keywords):
     for keyword in keywords:
         keyword_prefix = keyword.split("(")[0].lower()
         keyword_ind = KEYWORD_ID_DICT.get(keyword_prefix)
-        if keyword_ind:
+        # keyword_ind can be 0 which if 0: evaluates to False
+        if keyword_ind is not None:
             mapped_keywords.append(keyword_ind)
             if keyword_prefix in ("intent", "dimension", "pass"):
                 keyword_substring = get_paren_substring(keyword)

--- a/fortls/interface.py
+++ b/fortls/interface.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from ._version import __version__
+
+
+class SetAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, set(values))
+
+
+def commandline_args() -> argparse.ArgumentParser:
+    """Parses the command line arguments to the Language Server
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        command line arguments
+    """
+
+    parser = argparse.ArgumentParser(
+        description=f"fortls {__version__}",
+        prog=__name__,
+        usage="%(prog)s [options] [debug options]",
+        formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=60),
+    )
+
+    # General options ----------------------------------------------------------
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="store_true",
+        help="Print server version number and exit",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        type=str,
+        default=".fortls",
+        help="Configuration options file (default file name: %(default)s)",
+    )
+    parser.add_argument(
+        "-n",
+        "--nthreads",
+        type=int,
+        default=4,
+        help=(
+            "Number of threads to use during workspace initialization (default:"
+            " %(default)s)"
+        ),
+    )
+    parser.add_argument(
+        "--notify_init",
+        action="store_true",
+        help="Send notification message when workspace initialization is complete",
+    )
+    parser.add_argument(
+        "--incremental_sync",
+        action="store_true",
+        help="Use incremental document synchronization (beta)",
+    )
+    parser.add_argument(
+        "--sort_keywords",
+        action="store_true",
+        help=(
+            "Display variable keywords information, function/subroutine definitions,"
+            " etc. in a consistent (sorted) manner default: no sorting, display code"
+            " as is)"
+        ),
+    )
+    # XXX: Deprecated, argument not attached to anything. Remove
+    parser.add_argument(
+        "--preserve_keyword_order",
+        action="store_true",
+        help="DEPRECATED options, this is now the default. To sort use sort_keywords",
+    )
+    parser.add_argument(
+        "--debug_log",
+        action="store_true",
+        help="Generate debug log in project root folder",
+    )
+    parser.add_argument(
+        "--debug_help", action="help", help="Display options for debugging fortls"
+    )
+
+    # File parsing options -----------------------------------------------------
+    group = parser.add_argument_group("File parsing options")
+    group.add_argument(
+        "--source_dirs",
+        type=str,
+        nargs="*",
+        default=set(),
+        action=SetAction,
+        help="Folders containing source files (default: %(default)s)",
+    )
+    group.add_argument(
+        "--incl_suffixes",
+        type=str,
+        nargs="*",
+        help=(
+            "Consider additional file extensions to the default (default: "
+            "F,F77,F90,F95,F03,F08,FOR,FPP (lower & upper casing))"
+        ),
+    )
+    group.add_argument(
+        "--excl_suffixes",
+        type=str,
+        nargs="*",
+        default=set(),
+        action=SetAction,
+        help="Source file extensions to be excluded (default: %(default)s)",
+    )
+    group.add_argument(
+        "--excl_paths",
+        type=str,
+        nargs="*",
+        default=set(),
+        action=SetAction,
+        help="Folders to exclude from parsing",
+    )
+
+    # Autocomplete options -----------------------------------------------------
+    group = parser.add_argument_group("Autocomplete options")
+    group.add_argument(
+        "--autocomplete_no_prefix",
+        action="store_true",
+        help="Do not filter autocomplete results by variable prefix",
+    )
+    group.add_argument(
+        "--autocomplete_no_snippets",
+        action="store_true",
+        help="Do not use snippets with place holders in autocomplete results",
+    )
+    group.add_argument(
+        "--autocomplete_name_only",
+        action="store_true",
+        help="Complete only the name of procedures and not the parameters",
+    )
+    group.add_argument(
+        "--lowercase_intrinsics",
+        action="store_true",
+        help="Use lowercase for intrinsics and keywords in autocomplete requests",
+    )
+    group.add_argument(
+        "--use_signature_help",
+        action="store_true",
+        help="Use signature help instead of subroutine/function snippets",
+    )
+
+    # Hover options ------------------------------------------------------------
+    group = parser.add_argument_group("Hover options")
+    group.add_argument(
+        "--variable_hover",
+        action="store_true",
+        help=(
+            "Show hover information for variables (default: subroutines/functions only)"
+        ),
+    )
+    group.add_argument(
+        "--hover_signature",
+        action="store_true",
+        help=(
+            "Show signature information in hover for arguments "
+            "(also enables '--variable_hover')"
+        ),
+    )
+    group.add_argument(
+        "--hover_language",
+        type=str,
+        default="fortran90",
+        help=(
+            "Language used for responses to hover requests a VSCode language id"
+            " (default: %(default)s)"
+        ),
+    )
+
+    # Diagnostic options -------------------------------------------------------
+    group = parser.add_argument_group("Diagnostic options (error swigles)")
+    group.add_argument(
+        "--max_line_length",
+        type=int,
+        default=-1,
+        help="Maximum line length (default: %(default)s)",
+    )
+    group.add_argument(
+        "--max_comment_line_length",
+        type=int,
+        default=-1,
+        help="Maximum comment line length (default: %(default)s)",
+    )
+    group.add_argument(
+        "--disable_diagnostics", action="store_true", help="Disable diagnostics"
+    )
+
+    # Preprocessor options -----------------------------------------------------
+    group = parser.add_argument_group("Preprocessor options")
+    group.add_argument(
+        "--pp_suffixes",
+        type=str,
+        nargs="*",
+        help="File extensions to be parsed ONLY for preprocessor commands",
+        # TODO: add a default that is an empty list?
+        # TODO: make a set?
+    )
+    group.add_argument(
+        "--include_dirs",
+        # "--pp_include_dirs",  # TODO: make main
+        type=str,
+        nargs="*",
+        default=list(),
+        help="Folders containing preprocessor files with extensions PP_SUFFIXES.",
+    )
+    group.add_argument(
+        "--pp_defs",
+        type=json.loads,
+        default={},
+        help=(
+            "A dictionary with additional preprocessor definitions. "
+            "Preprocessor definitions are normally included via INCLUDE_DIRS"
+        ),
+    )
+
+    # Symbols options ----------------------------------------------------------
+    group = parser.add_argument_group("Symbols options")
+    group.add_argument(
+        "--symbol_skip_mem",
+        action="store_true",
+        help="Do not include type members in document symbol results",
+    )
+
+    # Code Actions options -----------------------------------------------------
+    group = parser.add_argument_group("CodeActions options [limited]")
+    group.add_argument(
+        "--enable_code_actions",
+        action="store_true",
+        help="Enable experimental code actions (default: false)",
+    )
+
+    # Debug
+    # By default debug arguments are hidden
+    _debug_commandline_args(parser)
+
+    return parser
+
+
+# TODO: make this return a parser
+def _debug_commandline_args(parser: argparse.ArgumentParser) -> None:
+    """Parse the debug arguments if any are present.
+    if none are present the arguments are suppressed in the help menu
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        an argument parser
+
+    Returns
+    -------
+    None
+        Operates and updates the parser
+    """
+
+    # Only show debug options if an argument starting with --debug_ was input.
+    # if suppressed the option will be hidden from the help menu.
+    HIDE_DEBUG = True
+    if any("--debug_" in arg for arg in sys.argv):
+        HIDE_DEBUG = False
+
+    def hide_opt(help: str) -> str:
+        if not HIDE_DEBUG:
+            return help
+        else:
+            return argparse.SUPPRESS
+
+    group = parser.add_argument_group(
+        hide_opt("DEBUG"), hide_opt("Options for debugging language server")
+    )
+    group.add_argument(
+        "--debug_parser",
+        action="store_true",
+        help=hide_opt("Test source code parser on specified file"),
+    )
+    group.add_argument(
+        "--debug_diagnostics",
+        action="store_true",
+        help=hide_opt("Test diagnostic notifications for specified file"),
+    )
+    group.add_argument(
+        "--debug_symbols",
+        action="store_true",
+        help=hide_opt("Test symbol request for specified file"),
+    )
+    group.add_argument(
+        "--debug_workspace_symbols",
+        type=str,
+        help=hide_opt("Test workspace/symbol request"),
+    )
+    group.add_argument(
+        "--debug_completion",
+        action="store_true",
+        help=hide_opt("Test completion request for specified file and position"),
+    )
+    group.add_argument(
+        "--debug_signature",
+        action="store_true",
+        help=hide_opt("Test signatureHelp request for specified file and position"),
+    )
+    group.add_argument(
+        "--debug_definition",
+        action="store_true",
+        help=hide_opt("Test definition request for specified file and position"),
+    )
+    group.add_argument(
+        "--debug_hover",
+        action="store_true",
+        help=hide_opt("Test hover request for specified file and position"),
+    )
+    group.add_argument(
+        "--debug_implementation",
+        action="store_true",
+        help=hide_opt("Test implementation request for specified file and position"),
+    )
+    group.add_argument(
+        "--debug_references",
+        action="store_true",
+        help=hide_opt("Test references request for specified file and position"),
+    )
+    group.add_argument(
+        "--debug_rename",
+        type=str,
+        help=hide_opt("Test rename request for specified file and position"),
+    )
+    group.add_argument(
+        "--debug_actions",
+        action="store_true",
+        help=hide_opt("Test codeAction request for specified file and position"),
+    )
+    group.add_argument(
+        "--debug_filepath",
+        type=str,
+        help=hide_opt("File path for language server tests"),
+    )
+    group.add_argument(
+        "--debug_rootpath",
+        type=str,
+        help=hide_opt("Root path for language server tests"),
+    )
+    group.add_argument(
+        "--debug_line",
+        type=int,
+        help=hide_opt("Line position for language server tests (1-indexed)"),
+    )
+    group.add_argument(
+        "--debug_char",
+        type=int,
+        help=hide_opt("Character position for language server tests (1-indexed)"),
+    )
+    group.add_argument(
+        "--debug_full_result",
+        action="store_true",
+        help=hide_opt("Print full result object instead of condensed version"),
+    )

--- a/fortls/parse_fortran.py
+++ b/fortls/parse_fortran.py
@@ -775,9 +775,9 @@ class fortran_file:
         self.preproc: bool = False
         self.ast: fortran_ast = None
         self.hash: str = None
-        if path is not None:
+        if path:
             _, file_ext = os.path.splitext(os.path.basename(path))
-            if pp_suffixes is not None:
+            if pp_suffixes:
                 self.preproc = file_ext in pp_suffixes
             else:
                 self.preproc = file_ext == file_ext.upper()

--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -48,7 +48,7 @@ END_INT_REGEX = re.compile(r"INTERFACE", re.I)
 END_WORD_REGEX = re.compile(
     r"[ ]*END[ ]*(DO|WHERE|IF|BLOCK|ASSOCIATE|SELECT"
     r"|TYPE|ENUM|MODULE|SUBMODULE|PROGRAM|INTERFACE"
-    r"|SUBROUTINE|FUNCTION|PROCEDURE)?([ ]+(?!\W)|$)",
+    r"|SUBROUTINE|FUNCTION|PROCEDURE|FORALL)?([ ]+(?!\W)|$)",
     re.I,
 )
 TYPE_DEF_REGEX = re.compile(r"[ ]*(TYPE)[, :]+", re.I)

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -1,0 +1,165 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fortls.interface import commandline_args  # noqa: E402
+
+parser = commandline_args("fortls")
+
+
+def test_command_line_general_options():
+    args = parser.parse_args(
+        "-c config_file.json -n 2 --notify_init --incremental_sync --sort_keywords"
+        " --debug_log".split()
+    )
+    assert args.config == "config_file.json"
+    assert args.nthreads == 2
+    assert args.notify_init
+    assert args.incremental_sync
+    assert args.sort_keywords
+    assert args.debug_log
+
+
+def test_command_line_file_parsing_options():
+    args = parser.parse_args(
+        "--source_dirs tmp ./local /usr/include/** --incl_suffixes .FF .fpc .h f20"
+        " --excl_suffixes _tmp.f90 _h5hut_tests.F90 --excl_paths exclude tests".split()
+    )
+    assert args.source_dirs == set(["tmp", "./local", "/usr/include/**"])
+    assert args.incl_suffixes == [".FF", ".fpc", ".h", "f20"]
+    assert args.excl_suffixes == set(["_tmp.f90", "_h5hut_tests.F90"])
+    assert args.excl_paths == set(["exclude", "tests"])
+
+
+def test_command_line_autocomplete_options():
+    args = parser.parse_args(
+        "--autocomplete_no_prefix --autocomplete_no_snippets --autocomplete_name_only"
+        " --lowercase_intrinsics --use_signature_help".split()
+    )
+    assert args.autocomplete_no_prefix
+    assert args.autocomplete_no_snippets
+    assert args.autocomplete_name_only
+    assert args.lowercase_intrinsics
+    assert args.use_signature_help
+
+
+def test_command_line_hover_options():
+    args = parser.parse_args(
+        "--variable_hover --hover_signature --hover_language FortranFreeForm".split()
+    )
+    assert args.variable_hover
+    assert args.hover_signature
+    assert args.hover_language == "FortranFreeForm"
+
+
+def test_command_line_diagnostic_options():
+    args = parser.parse_args(
+        "--max_line_length 80 --max_comment_line_length 8 --disable_diagnostics".split()
+    )
+    assert args.max_line_length == 80
+    assert args.max_comment_line_length == 8
+    assert args.disable_diagnostics
+
+
+def test_command_line_preprocessor_options():
+    args = parser.parse_args(
+        "--pp_suffixes .h .fh --include_dirs /usr/include/** ./local/incl --pp_defs"
+        ' {"HAVE_PETSC":"","HAVE_ZOLTAN":"","Mat":"type(tMat)"}'.split()
+    )
+    assert args.pp_suffixes == [".h", ".fh"]
+    assert args.include_dirs == ["/usr/include/**", "./local/incl"]
+    assert args.pp_defs == {"HAVE_PETSC": "", "HAVE_ZOLTAN": "", "Mat": "type(tMat)"}
+
+
+def test_command_line_symbol_options():
+    args = parser.parse_args("--symbol_skip_mem".split())
+    assert args.symbol_skip_mem
+
+
+def test_command_line_code_actions_options():
+    args = parser.parse_args("--enable_code_actions".split())
+    assert args.enable_code_actions
+
+
+def unittest_server_init():
+    from fortls.langserver import LangServer
+
+    root = os.path.join(os.path.dirname(__file__), "test_source")
+    parser = commandline_args("fortls")
+    args = parser.parse_args("-c f90_config.json".split())
+
+    server = LangServer(None, vars(args))
+    server.root_path = root
+    server._load_config_file()
+
+    return server, root
+
+
+def test_config_file_general_options():
+    server, root = unittest_server_init()
+    assert server.nthreads == 8
+    assert server.notify_init
+    assert server.incremental_sync
+    assert server.sort_keywords
+
+
+def test_config_file_dir_parsing_options():
+    server, root = unittest_server_init()
+    # File parsing
+    assert server.source_dirs == set(
+        [f"{root}/subdir", f"{root}/pp", f"{root}/pp/include"]
+    )
+    assert server.incl_suffixes == [".FF", ".fpc", ".h", "f20"]
+    assert server.excl_suffixes == set(["_tmp.f90", "_h5hut_tests.F90"])
+    assert server.excl_paths == set([f"{root}/excldir", f"{root}/hover"])
+
+
+def test_config_file_autocomplete_options():
+    server, root = unittest_server_init()
+    # Autocomplete options
+    assert server.autocomplete_no_prefix
+    assert server.autocomplete_no_snippets
+    assert server.autocomplete_name_only
+    assert server.lowercase_intrinsics
+    assert server.use_signature_help
+
+
+def test_config_file_hover_options():
+    server, root = unittest_server_init()
+    # Hover options
+    assert server.variable_hover
+    assert server.hover_signature
+    assert server.hover_language == "FortranFreeForm"
+
+
+def test_config_file_diagnostic_options():
+    server, root = unittest_server_init()
+    # Diagnostic options
+    assert server.max_line_length == 80
+    assert server.max_comment_line_length == 80
+    assert server.disable_diagnostics
+
+
+def test_config_file_preprocessor_options():
+    server, root = unittest_server_init()
+    # Preprocessor options
+    assert server.pp_suffixes == [".h", ".fh"]
+    assert server.include_dirs == [f"{root}/include"]
+    assert server.pp_defs == {
+        "HAVE_PETSC": "",
+        "HAVE_ZOLTAN": "",
+        "Mat": "type(tMat)",
+    }
+
+
+def test_config_file_symbols_options():
+    server, root = unittest_server_init()
+    # Symbols options
+    assert server.symbol_skip_mem
+
+
+def test_config_file_codeactions_options():
+    server, root = unittest_server_init()
+    # Code Actions options
+    assert server.enable_code_actions

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -521,6 +521,8 @@ def test_hover():
     string += hover_req(file_path, 6, 28)
     string += hover_req(file_path, 7, 38)
     string += hover_req(file_path, 7, 55)
+    file_path = os.path.join(test_dir, "hover", "pointers.f90")
+    string += hover_req(file_path, 1, 26)
     errcode, results = run_request(
         string, fortls_args=" --variable_hover --sort_keywords"
     )
@@ -537,6 +539,7 @@ def test_hover():
         "INTEGER, PARAMETER :: var4 = 123",
         "DOUBLE PRECISION, PARAMETER :: somevar = 23.12",
         "DOUBLE PRECISION, PARAMETER :: some = 1e-19",
+        "INTEGER, POINTER",
     )
     assert len(ref_results) == len(results) - 1
     check_return(results[1:], ref_results)

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -178,6 +178,7 @@ def test_workspace_symbols():
             ["test", 6, 7],
             ["test_abstract", 2, 0],
             ["test_external", 2, 0],
+            ["test_forall", 2, 0],
             ["test_free", 2, 0],
             ["test_gen_type", 5, 1],
             ["test_generic", 2, 0],
@@ -603,6 +604,7 @@ def test_diagnostics():
 
     def check_return(results, ref_results):
         for i, r in enumerate(results):
+            print(r["diagnostics"], ref_results[i])
             assert r["diagnostics"] == ref_results[i]
 
     string = write_rpc_request(1, "initialize", {"rootPath": test_dir})
@@ -633,8 +635,15 @@ def test_diagnostics():
     string += write_rpc_notification(
         "textDocument/didOpen", {"textDocument": {"uri": file_path}}
     )
+    # Checks that forall with end forall inside a case select does not cause
+    # unexpected end of scope.
+    file_path = os.path.join(test_dir, "diag", "test_forall.f90")
+    string += write_rpc_notification(
+        "textDocument/didOpen", {"textDocument": {"uri": file_path}}
+    )
     errcode, results = run_request(string)
     assert errcode == 0
+    file_path = os.path.join(test_dir, "diag", "test_external.f90")
     ref_results = [
         [],
         [],
@@ -682,6 +691,7 @@ def test_diagnostics():
                 ],
             },
         ],
+        [],
     ]
     check_return(results[1:], ref_results)
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -521,7 +521,9 @@ def test_hover():
     string += hover_req(file_path, 6, 28)
     string += hover_req(file_path, 7, 38)
     string += hover_req(file_path, 7, 55)
-    errcode, results = run_request(string, fortls_args=" --variable_hover")
+    errcode, results = run_request(
+        string, fortls_args=" --variable_hover --sort_keywords"
+    )
     assert errcode == 0
     #
     ref_results = (

--- a/test/test_source/diag/test_forall.f90
+++ b/test/test_source/diag/test_forall.f90
@@ -1,0 +1,14 @@
+program test_forall
+   implicit none
+   integer :: i, j, dim=3, a(10) = 2
+
+   select case (dim)
+    case(3)
+      forall(i=1:10)
+         a(i) = a(i) **2
+         forall (j=1:i) a(j) = a(j) ** 2
+      end forall
+    case default
+      call abort()
+   end select
+end program test_forall

--- a/test/test_source/excldir/sub1/tmp.f90
+++ b/test/test_source/excldir/sub1/tmp.f90
@@ -1,0 +1,22 @@
+module oumods
+  use, intrinsic :: iso_c_binding
+  implicit integer(c_int) (i-k), integer(c_int) (m,n), &
+       & real(c_double) (a-h), real(c_double) (l), real(c_double) (o-z)
+
+       TYPE :: ex_type
+       INTEGER :: A = 0
+     CONTAINS
+       FINAL :: del_ex_type
+       PROCEDURE :: sub => ex_sub
+     END TYPE ex_type
+     
+contains
+  subroutine zI12(t,c,alpha,beta,r)
+    complex(c_double_complex) c,r,    x,y,z
+     z = c*t
+     y = exp(z)
+     x = (2.0_c_double * cosh((z - cmplx(0._c_double,3.14159265358979324_c_double, kind(1._c_double))) &
+          & /2._c_double )) / (c / exp((z + cmplx(0._c_double,3.14159265358979324_c_double,kind(1._c_double)))/2._c_double))
+     r = beta*r+alpha*((t*y - x)/c)
+  end subroutine
+end module

--- a/test/test_source/f90_config.json
+++ b/test/test_source/f90_config.json
@@ -1,0 +1,37 @@
+{
+  "nthreads": 8,
+  "notify_init": true,
+  "incremental_sync": true,
+  "sort_keywords": true,
+
+  "source_dirs": ["subdir", "pp/**"],
+  "incl_suffixes": [".FF", ".fpc", ".h", "f20"],
+  "excl_suffixes": ["_tmp.f90", "_h5hut_tests.F90"],
+  "excl_paths": ["excldir", "hover/**"],
+
+  "autocomplete_no_prefix": true,
+  "autocomplete_no_snippets": true,
+  "autocomplete_name_only": true,
+  "lowercase_intrinsics": true,
+  "use_signature_help": true,
+
+  "variable_hover": true,
+  "hover_signature": true,
+  "hover_language": "FortranFreeForm",
+
+  "max_line_length": 80,
+  "max_comment_line_length": 80,
+  "disable_diagnostics": true,
+
+  "pp_suffixes": [".h", ".fh"],
+  "include_dirs": ["./include/**"],
+  "pp_defs": {
+    "HAVE_PETSC": "",
+    "HAVE_ZOLTAN": "",
+    "Mat": "type(tMat)"
+  },
+
+  "symbol_skip_mem": true,
+
+  "enable_code_actions": true
+}

--- a/test/test_source/hover/pointers.f90
+++ b/test/test_source/hover/pointers.f90
@@ -1,0 +1,3 @@
+program pointers
+    INTEGER, POINTER :: val1
+end program


### PR DESCRIPTION
- Updates documentation
- Updates LICENSE
- Updates .gitignore
- Adds field in documentation about all the changes (extracted from the changelog) between this project and fortran-language-server.
- Unifies the interface between command line arguments and configuration file interface
- Deprecates `preserve_keyword_order`
