### PR TITLE
Fix text completion for procedures

### DIFF
--- a/fortls/objects.py
+++ b/fortls/objects.py
@@ -427,9 +427,9 @@ class fortran_obj:
         for i, arg in enumerate(arg_list):
             opt_split = arg.split("=")
             if len(opt_split) > 1:
-                place_holders.append(f"{opt_split[0]}=${{{i+1}}}:{{{opt_split[1]}}}")
+                place_holders.append(f"{opt_split[0]}=${{{i+1}:{opt_split[1]}}}")
             else:
-                place_holders.append(f"${{{i+1}}}:{{{arg}}}")
+                place_holders.append(f"${{{i+1}:{arg}}}")
         arg_str = f"({', '.join(arg_list)})"
         arg_snip = f"({', '.join(place_holders)})"
         return arg_str, arg_snip


### PR DESCRIPTION
Remove extra curly brackets introduced in a82f4e2

Fixes #39

The existing tests don't capture this. I had a look at adding one:

```python
def test_procedure_completion():
    def comp_request(file_path, line, char):
        return write_rpc_request(
            1,
            "textDocument/completion",
            {
                "textDocument": {"uri": str(file_path)},
                "position": {"line": line, "character": char},
            },
        )

    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
    file_path = test_dir / "test_prog.f08"
    string += comp_request(file_path, 26, 17)
    errcode, results = run_request(string)
    assert errcode == 0

    exp_results = (
        {
            "label": "test_sig_Sub",
            "insertText": "test_sig_Sub(${1:arg1}, ${2:arg2}, opt1=${3:opt1}, opt2=${4:opt2}, opt3=${5:opt3})",
        },
    )
    print(results[1])
    for expected_result, result in zip(exp_results, results[1:]):
        for key, value in expected_result.items():
            assert result[0][key] == value
```

But the `insertText` in the results was just `test_sig_Sub` and doesn't include the arguments. A quick look at the LSP spec, and possibly the action needs to be `completion resolve` perhaps? I'm not sure how to construct one of those at the low level used in the tests.