### PR TITLE
Fix error in Windows in zh_CN locale

### DIFF
--- a/fortls/intrinsics.py
+++ b/fortls/intrinsics.py
@@ -142,7 +142,7 @@ def load_intrinsics():
         os.path.dirname(os.path.abspath(__file__)), "statements.json"
     )
     statements = {"var_def": [], "int_stmnts": []}
-    with open(json_file, "r") as fid:
+    with open(json_file, "r", encoding="utf-8") as fid:
         intrin_file = json.load(fid)
         for key in statements:
             for name, json_obj in sorted(intrin_file[key].items()):
@@ -153,7 +153,7 @@ def load_intrinsics():
         os.path.dirname(os.path.abspath(__file__)), "keywords.json"
     )
     keywords = {"var_def": [], "arg": [], "type_mem": [], "vis": [], "param": []}
-    with open(json_file, "r") as fid:
+    with open(json_file, "r", encoding="utf-8") as fid:
         intrin_file = json.load(fid)
         for key in keywords:
             for name, json_obj in sorted(intrin_file[key].items()):
@@ -164,7 +164,7 @@ def load_intrinsics():
         os.path.dirname(os.path.abspath(__file__)), "intrinsic_funs.json"
     )
     int_funs = []
-    with open(json_file, "r") as fid:
+    with open(json_file, "r", encoding="utf-8") as fid:
         intrin_file = json.load(fid)
         for name, json_obj in sorted(intrin_file.items()):
             int_funs.append(create_int_object(name, json_obj, json_obj["type"]))
@@ -175,7 +175,7 @@ def load_intrinsics():
         os.path.dirname(os.path.abspath(__file__)), "intrinsic_mods.json"
     )
     int_mods = []
-    with open(json_file, "r") as fid:
+    with open(json_file, "r", encoding="utf-8") as fid:
         intrin_file = json.load(fid)
         for key, json_obj in intrin_file.items():
             fort_obj = create_object(json_obj)


### PR DESCRIPTION
By default python in Windows in zh_CN will use GBK to open files, since we're using UTF-8 now, it will throw error like this:

```
Traceback (most recent call last):
  File "C:\Program Files\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Program Files\Python310\Scripts\fortls.exe\__main__.py", line 7, in <module>
  File "C:\Program Files\Python310\lib\site-packages\fortls\__init__.py", line 56, in main
    LangServer(
  File "C:\Program Files\Python310\lib\site-packages\fortls\langserver.py", line 119, in __init__
    ) = load_intrinsics()
  File "C:\Program Files\Python310\lib\site-packages\fortls\intrinsics.py", line 168, in load_intrinsics
    intrin_file = json.load(fid)
  File "C:\Program Files\Python310\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'gbk' codec can't decode byte 0x99 in position 11899: illegal multibyte sequence
```