### PR TITLE
Do not require parentheses for the `defined` preprocessor operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Updated `setup.cfg` in preparation of submitting package to `conda-forge`
 - Added `Editor Integration` section in documentation
 
+### Fixed
+
+- Fixed parsing of `defined` without by parenthesis surrounding the definition
+  ([#67](https://github.com/gnikit/fortls/pull/67))
+
 ## 2.2.4
 
 ### Fixed

--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -110,7 +110,7 @@ class FortranRegularExpressions:
     FREE_OPENMP: Pattern = compile(r"[ ]*!\$OMP", I)
     FREE_FORMAT_TEST: Pattern = compile(r"[ ]{1,4}[a-z]", I)
     # Preprocessor matching rules
-    DEFINED: Pattern = compile(r"defined[ ]*\([ ]*([a-z_][a-z0-9_]*)[ ]*\)", I)
+    DEFINED: Pattern = compile(r"defined[ ]*\(?[ ]*([a-z_][a-z0-9_]*)[ ]*\)?", I)
     PP_REGEX: Pattern = compile(r"#(if |ifdef|ifndef|else|elif|endif)")
     PP_DEF: Pattern = compile(r"#(define|undef)[ ]*([\w]+)(\((\w+(,[ ]*)?)+\))?", I)
     PP_DEF_TEST: Pattern = compile(r"(![ ]*)?defined[ ]*\([ ]*([a-z0-9_]*)[ ]*\)$", I)

--- a/test/test_preproc.py
+++ b/test/test_preproc.py
@@ -27,6 +27,7 @@ def test_hover():
     string += hover_req(file_path, 7, 40)  # multi-lin variable
     string += hover_req(file_path, 8, 7)  # function with if conditional
     string += hover_req(file_path, 9, 7)  # multiline function with if conditional
+    string += hover_req(file_path, 10, 15)  # defined without ()
     file_path = root_dir / "preproc_keywords.F90"
     string += hover_req(file_path, 6, 2)  # ignores PP across Fortran line continuations
     config = str(root_dir / ".pp_conf.json")
@@ -40,6 +41,7 @@ def test_hover():
         "#define varVar 55",
         "#define ewrite if (priority <= 3) write((priority), format)",
         "#define ewrite2 if (priority <= 3) write((priority), format)",
+        "#define SUCCESS .true.",
         "REAL, CONTIGUOUS, POINTER, DIMENSION(:)",
     )
     assert len(ref_results) == len(results) - 1

--- a/test/test_source/pp/include/petscerror.h
+++ b/test/test_source/pp/include/petscerror.h
@@ -4,4 +4,9 @@
 #define PETSC_ERR_MEM              55
 #define PETSC_ERR_INT_OVERFLOW     84
 #define PETSC_ERR_FLOP_COUNT       90
+
+#if defined PETSC_ERR_MEM || defined PETSC_ERR_INT_OVERFLOW
+#define SUCCESS .true.
+#endif
+
 #endif

--- a/test/test_source/pp/preproc.F90
+++ b/test/test_source/pp/preproc.F90
@@ -8,6 +8,7 @@ program preprocessor
     print*, PETSC_ERR_INT_OVERFLOW, varVar
     ewrite(1,*) 'Assemble EP P1 matrix and rhs sytem'
     ewrite2(1,*) 'Assemble EP P1 matrix and rhs sytem'
+    print*, SUCCESS
 
 #endif
 end program preprocessor


### PR DESCRIPTION
The regex that checks for preprocessor macros using the 'defined'
operator assumes that the macro that follows the operator is between
parenthesis. However, the syntax for the 'defined' operator does not
require parenthesis, at least in GNU Cpp [1] and Intel fpp [2], arguably
the two most commonly used Fortran preprocessors.

Tweak the regex by allowing the opening and closing parenthesis zero or
once.

[1] https://gcc.gnu.org/onlinedocs/gcc-10.2.0/cpp/Defined.html#Defined
[2] https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/optimization-and-programming-guide/fpp-preprocessing/using-fpp-preprocessor-directives.html