### PR TITLE
Deprecated `--variable_hover`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 - Added the capability for `fortls` to auto-update use `--disable_autoupdate` to disable
   ([#76](https://github.com/gnikit/fortls/issues/76))
 
+## Deprecated
+
+- Deprecated `--variable_hover` option and now is always enabled
+  ([#46](https://github.com/gnikit/fortls/issues/46))
+
 ## 2.2.5
 
 ### Changed

--- a/fortls/interface.py
+++ b/fortls/interface.py
@@ -176,16 +176,13 @@ def commandline_args(name: str = "fortls") -> argparse.ArgumentParser:
         "--variable_hover",
         action="store_true",
         help=(
-            "Show hover information for variables (default: subroutines/functions only)"
+            "DEPRECATED: This option is always on. Show hover information for variables"
         ),
     )
     group.add_argument(
         "--hover_signature",
         action="store_true",
-        help=(
-            "Show signature information in hover for arguments "
-            "(also enables '--variable_hover')"
-        ),
+        help="Show signature information in hover for arguments ",
     )
     group.add_argument(
         "--hover_language",

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -101,7 +101,6 @@ class LangServer:
             setattr(self, k, v)
 
         self.sync_type: int = 2 if self.incremental_sync else 1
-        self.variable_hover: bool = self.variable_hover or self.hover_signature
         self.post_messages = []
         self.FORTRAN_SRC_EXT_REGEX: Pattern[str] = src_file_exts()
         # Intrinsic (re-loaded during initialize)
@@ -1049,7 +1048,7 @@ class LangServer:
                 hover_str, highlight = member.get_hover(long=True)
                 if hover_str is not None:
                     hover_array.append(create_hover(hover_str, highlight))
-        elif self.variable_hover and (var_type == VAR_TYPE_ID):
+        elif var_type == VAR_TYPE_ID:
             # Unless we have a Fortran literal include the desc in the hover msg
             # See get_definition for an explanation about this default name
             if not var_obj.desc.startswith(FORTRAN_LITERAL):
@@ -1516,7 +1515,6 @@ class LangServer:
         )
 
         # Hover options --------------------------------------------------------
-        self.variable_hover = config_dict.get("variable_hover", self.variable_hover)
         self.hover_signature = config_dict.get("hover_signature", self.hover_signature)
         self.hover_language = config_dict.get("hover_language", self.hover_language)
 

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -48,9 +48,8 @@ def test_command_line_autocomplete_options():
 
 def test_command_line_hover_options():
     args = parser.parse_args(
-        "--variable_hover --hover_signature --hover_language FortranFreeForm".split()
+        "--hover_signature --hover_language FortranFreeForm".split()
     )
-    assert args.variable_hover
     assert args.hover_signature
     assert args.hover_language == "FortranFreeForm"
 
@@ -131,7 +130,6 @@ def test_config_file_autocomplete_options():
 def test_config_file_hover_options():
     server, root = unittest_server_init()
     # Hover options
-    assert server.variable_hover
     assert server.hover_signature
     assert server.hover_language == "FortranFreeForm"
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -605,9 +605,7 @@ def test_hover():
     file_path = test_dir / "test_diagnostic_int.f90"
     string += hover_req(file_path, 19, 14)
 
-    errcode, results = run_request(
-        string, fortls_args=["--variable_hover", "--sort_keywords"]
-    )
+    errcode, results = run_request(string, fortls_args=["--sort_keywords"])
     assert errcode == 0
     #
     ref_results = (


### PR DESCRIPTION
Removes hooks for `--variable_hover`, now always enabled