### PR TITLE
Feature/conda skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 2.2.7
 
+### Changed
+
+- Changed the auto-update feature to skip `anaconda` environments since they
+  handle their dependencies through `conda` and not `pip`
+
 ### Fixed
 
 - Fixed missing dependency from `setup.cfg`

--- a/fortls/interface.py
+++ b/fortls/interface.py
@@ -22,7 +22,7 @@ def commandline_args(name: str = "fortls") -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="fortls - Fortran Language Server",
         prog=name,
-        usage="%(prog)s [options] [debug options]",
+        usage="fortls [options] [debug options]",
         formatter_class=lambda prog: argparse.HelpFormatter(prog, max_help_position=60),
         epilog=(
             "All options starting with '--' can also be set in a configuration file, by"

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -1665,10 +1665,13 @@ class LangServer:
                 # This is the only reliable way to compare version semantics
                 if version.parse(info["info"]["version"]) > v or test:
                     self.post_message(
-                        f"Using fortls {__version__}. A newer version of is"
-                        " available through PyPi. An attempt will be made to update"
-                        " the server",
-                        3,
+                        "A newer version of fortls is available for download", 3
+                    )
+                    # Anaconda environments should handle their updates through conda
+                    if os.path.exists(os.path.join(sys.prefix, "conda-meta")):
+                        return False
+                    self.post_message(
+                        f"Downloading from PyPi fortls {info['info']['version']}", 3
                     )
                     # Run pip
                     result = subprocess.run(

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -214,7 +214,9 @@ class LangServer:
         self._load_intrinsics()
         self._add_source_dirs()
         if self._update_version_pypi():
-            log.log("Please restart the server for new version to activate")
+            self.post_message(
+                "Please restart the server for the new version to activate", 3
+            )
 
         # Initialize workspace
         self.workspace_init()

--- a/test/test_interface.py
+++ b/test/test_interface.py
@@ -167,8 +167,8 @@ def test_config_file_codeactions_options():
 
 
 def test_version_update_pypi():
-    from fortls.langserver import LangServer
     from fortls.jsonrpc import JSONRPC2Connection, ReadWriter
+    from fortls.langserver import LangServer
 
     parser = commandline_args("fortls")
     args = parser.parse_args("-c f90_config.json".split())


### PR DESCRIPTION
- Edits the message displayed when `fortls` is out of date
- Skips installation for Anaconda environments through `pip`