### PR TITLE
Disable PyPi autoupdate for prereleases and dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELONG
 
+## 2.2.8
+
+### Changed
+
+- Disable PyPi autoupdating for pre-releases and dev versions
+
 ## 2.2.7
 
 ### Changed

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -1664,8 +1664,12 @@ class LangServer:
             request = urllib.request.Request("https://pypi.org/pypi/fortls/json")
             with urllib.request.urlopen(request) as resp:
                 info = json.loads(resp.read().decode("utf-8"))
+                remote_v = version.parse(info["info"]["version"])
+                # Do not update from remote if it is a prerelease
+                if remote_v.is_prerelease:
+                    return False
                 # This is the only reliable way to compare version semantics
-                if version.parse(info["info"]["version"]) > v or test:
+                if remote_v > v or test:
                     self.post_message(
                         "A newer version of fortls is available for download", 3
                     )


### PR DESCRIPTION
This should prevent `fortls` from fetching dev and pre-release versions