### PR TITLE
extended list of keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELONG
 
+## 2.2.11
+
+### Added
+
+- Improved autocompletion for Fortran statements F2018 compliant
+  ([#63](https://github.com/gnikit/fortls/issues/63))
+
 ## 2.2.10
 
 ### Fixed

--- a/fortls/intrinsics.py
+++ b/fortls/intrinsics.py
@@ -137,7 +137,7 @@ def load_intrinsics():
             add_children(child, child_obj)
 
     # Fortran statments taken from Intel Fortran documentation
-    # (https://software.intel.com/en-us/fortran-compiler-18.0-developer-guide)
+    # (https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/language-reference/a-to-z-reference)
     json_file = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "statements.json"
     )
@@ -148,7 +148,7 @@ def load_intrinsics():
             for name, json_obj in sorted(intrin_file[key].items()):
                 statements[key].append(create_int_object(name, json_obj, 15))
     # Fortran keywords taken from Intel Fortran documentation
-    # (https://software.intel.com/en-us/fortran-compiler-18.0-developer-guide)
+    # (https://www.intel.com/content/www/us/en/develop/documentation/fortran-compiler-oneapi-dev-guide-and-reference/top/language-reference/a-to-z-reference)
     json_file = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "keywords.json"
     )

--- a/fortls/keywords.json
+++ b/fortls/keywords.json
@@ -6,17 +6,35 @@
     "ASYNCHRONOUS": {
       "doc": "Specify that a variable can be used for asynchronous input and output."
     },
+    "BIND": {
+      "doc": "Specifies that an object is interoperable with C and has external linkage."
+    },
+    "CODIMENSION": {
+      "doc": "Specifies that an entity is a coarray, and specifies its corank and cobounds, if any."
+    },
     "CONTIGUOUS": {
       "doc": "Specify that the target of a pointer or an assumed-sized array is contiguous."
     },
     "DIMENSION(:)": {
       "doc": "Specify that an object is an array, and defines the shape of the array."
     },
+    "EXTERNAL": {
+      "doc": "Allows an external procedure, a dummy procedure, a procedure pointer, or a block data subprogram to be used as an actual argument. (To specify intrinsic procedures as actual arguments, use the INTRINSIC attribute.)"
+    },
+    "INTRINSIC": {
+      "doc": "Allows the specific name of an intrinsic procedure to be used as an actual argument."
+    },
     "POINTER": {
       "doc": "Specify that an object or a procedure is a pointer (a dynamic variable)."
     },
+    "PROTECTED": {
+      "doc": "Specifies limitations on the use of module entities."
+    },
     "TARGET": {
       "doc": "Specify that an object can become the target of a pointer."
+    },
+    "VOLATILE": {
+      "doc": "Specifies that the value of an object is entirely unpredictable, based on information local to the current program unit. It prevents objects from being optimized during compilation."
     }
   },
   "arg": {
@@ -34,6 +52,9 @@
     },
     "SAVE": {
       "doc": "Cause the values and definition of objects to be retained after execution of a RETURN or END statement in a subprogram."
+    },
+    "VALUE": {
+      "doc": "Specifies a type of argument association for a dummy argument."
     }
   },
   "type_mem": {

--- a/fortls/keywords.json
+++ b/fortls/keywords.json
@@ -1,10 +1,10 @@
 {
   "var_def": {
     "ALLOCATABLE": {
-      "doc": "Specify that an array is an allocatable array with a deferred shape."
+      "doc": "Specifies that an object is allocatable."
     },
     "ASYNCHRONOUS": {
-      "doc": "Specify that a variable can be used for asynchronous input and output."
+      "doc": "Specifies that a variable can be used for asynchronous input and output."
     },
     "BIND": {
       "doc": "Specifies that an object is interoperable with C and has external linkage."
@@ -13,25 +13,25 @@
       "doc": "Specifies that an entity is a coarray, and specifies its corank and cobounds, if any."
     },
     "CONTIGUOUS": {
-      "doc": "Specify that the target of a pointer or an assumed-sized array is contiguous."
+      "doc": "Specifies that the target of a pointer or an assumed-sized array is contiguous."
     },
     "DIMENSION(:)": {
-      "doc": "Specify that an object is an array, and defines the shape of the array."
+      "doc": "Specifies that an object is an array, and defines the shape of the array."
     },
     "EXTERNAL": {
-      "doc": "Allows an external procedure, a dummy procedure, a procedure pointer, or a block data subprogram to be used as an actual argument. (To specify intrinsic procedures as actual arguments, use the INTRINSIC attribute.)"
+      "doc": "Allows an external procedure, a dummy procedure, a procedure pointer, or a block data subprogram to be used as an actual argument."
     },
     "INTRINSIC": {
       "doc": "Allows the specific name of an intrinsic procedure to be used as an actual argument."
     },
     "POINTER": {
-      "doc": "Specify that an object or a procedure is a pointer (a dynamic variable)."
+      "doc": "Specifies that an object or a procedure is a pointer (a dynamic variable)."
     },
     "PROTECTED": {
       "doc": "Specifies limitations on the use of module entities."
     },
     "TARGET": {
-      "doc": "Specify that an object can become the target of a pointer."
+      "doc": "Specifies that an object can become the target of a pointer (it can be pointed to)."
     },
     "VOLATILE": {
       "doc": "Specifies that the value of an object is entirely unpredictable, based on information local to the current program unit. It prevents objects from being optimized during compilation."
@@ -39,19 +39,19 @@
   },
   "arg": {
     "INTENT(IN)": {
-      "doc": "Specify the intended use of one or more dummy arguments."
+      "doc": "Specifies that the dummy argument will be used only to provide data to the procedure."
     },
     "INTENT(OUT)": {
-      "doc": "Specify the intended use of one or more dummy arguments."
+      "doc": "Specifies that the dummy argument will be used to pass data from the procedure back to the calling program."
     },
     "INTENT(INOUT)": {
-      "doc": "Specify the intended use of one or more dummy arguments."
+      "doc": "Specifies that the dummy argument can both provide data to the procedure and return data to the calling program."
     },
     "OPTIONAL": {
-      "doc": "Allow dummy arguments to be omitted in a procedure reference."
+      "doc": "Permits dummy arguments to be omitted in a procedure reference."
     },
     "SAVE": {
-      "doc": "Cause the values and definition of objects to be retained after execution of a RETURN or END statement in a subprogram."
+      "doc": "Causes the values and definition of objects to be retained after execution of a RETURN or END statement in a subprogram."
     },
     "VALUE": {
       "doc": "Specifies a type of argument association for a dummy argument."
@@ -59,16 +59,16 @@
   },
   "type_mem": {
     "DEFERRED": {
-      "doc": "Indicate that the procedure is deferred. Deferred bindings must only be specified for derived-type definitions with the ABSTRACT attribute."
+      "doc": "Indicates that the procedure is deferred. Deferred bindings must only be specified for derived-type definitions with the ABSTRACT attribute."
     },
     "NON_OVERRIDABLE": {
-      "doc": "Determine whether a binding can be overridden in an extended type."
+      "doc": "Determines whether a binding can be overridden in an extended type. You must not specify NON_OVERRIDABLE for a binding with the DEFERRED attribute."
     },
     "NOPASS": {
       "doc": "Indicate that the procedure has no passed-object dummy argument."
     },
     "PASS": {
-      "doc": "Define the 'passed-object dummy argument' of the procedure.",
+      "doc": "Indicates that the procedure has no passed-object dummy argument.",
       "args": "arg_name"
     }
   },

--- a/fortls/statements.json
+++ b/fortls/statements.json
@@ -12,37 +12,71 @@
   },
   "int_stmnts": {
     "ALLOCATE": {
-      "doc": "Dynamically create storage for allocatable variables and pointer targets."
+      "doc": "Dynamically creates storage for allocatable variables and pointer targets."
+    },
+    "BACKSPACE": {
+      "doc": "Positions a sequential file at the beginning of the preceding record, making it available for subsequent I/O processing."
     },
     "CALL": {
       "doc": "Transfers control to a subroutine subprogram."
     },
     "CLOSE": {
-      "doc": "Disconnect a file from a unit."
+      "doc": "Disconnects a file from a unit."
+    },
+    "CONTINUE": {
+      "doc": "Primarily used to terminate a labelled DO construct when the construct would otherwise end improperly with either a GO TO, arithmetic IF, or other prohibited control statement."
     },
     "CYCLE": {
-      "doc": "Interrupt the current execution cycle of the innermost (or named) DO construct."
+      "doc": "Interrupts the current execution cycle of the innermost (or named) DO construct."
     },
     "DEALLOCATE": {
-      "doc": "Free the storage allocated for allocatable variables and nonprocedure pointer targets (and causes the pointers to become disassociated)."
+      "doc": "Frees the storage allocated for allocatable variables and nonprocedure pointer targets (and causes the pointers to become disassociated)."
+    },
+    "ENDFILE": {
+      "doc": "For sequential files, writes an end-of-file record to the file and positions the file after this record (the terminal point)."
+    },
+    "ERROR STOP": {
+      "doc": "Initiates error termination of an image before the execution of an END statement of the main program."
+    },
+    "EVENT POST": {
+      "doc": "Allows an image to notify another image that it can proceed to work on tasks that use common resources."
+    },
+    "EVENT WAIT": {
+      "doc": "Allows an image to wait on events posted by other images."
+    },
+    "FAIL IMAGE": {
+      "doc": "Forces the failure of the current image of the program unit."
+    },
+    "FLUSH": {
+      "doc": "Causes data written to a file to become available to other processes or causes data written to a file outside of Fortran to be accessible to a READ statement."
+    },
+    "FORM TEAM": {
+      "args": "team_number,team_variable",
+      "doc": "Defines team variables; creates one or more teams of images from the images on the current team."
     },
     "FORMAT": {
-      "doc": "Specify the form of data being transferred and the data conversion (editing) required to achieve that form."
+      "doc": "Specifies the form of data being transferred and the data conversion (editing) required to achieve that form."
     },
     "INQUIRE": {
-      "doc": "Return information on the status of specified properties of a file, logical unit, or directory."
+      "doc": "Returns information on the status of specified properties of a file or logical unit."
+    },
+    "LOCK": {
+      "doc": "Causes a lock variable to become locked by an image."
     },
     "NAMELIST": {
       "doc": "Associates a name with a list of variables. This group name can be referenced in some input/output operations."
     },
     "NULLIFY": {
-      "doc": "Disassociate a pointer from a target."
+      "doc": "Disassociates a pointer from a target."
     },
     "OPEN": {
-      "doc": "Connect an external file to a unit, creates a new file and connects it to a unit, creates a preconnected file, or changes certain properties of a connection."
+      "doc": "Connects an external file to a unit, creates a new file and connects it to a unit, creates a preconnected file, or changes certain properties of a connection."
+    },
+    "PRINT": {
+      "doc": "Displays output on the screen."
     },
     "READ": {
-      "doc": "Transfer input data from external sequential, direct-access, or internal records."
+      "doc": "Transfers input data from external sequential, direct-access, or internal records."
     },
     "RETURN": {
       "doc": "Return control to the calling program unit."
@@ -51,10 +85,32 @@
       "doc": "Positions a sequential or direct access file at the beginning of the file (the initial point)."
     },
     "STOP": {
-      "doc": "Terminate execution of the program."
+      "doc": "Initiates normal termination of an image before the execution of an END statement of the main program."
+    },
+    "SYNC ALL": {
+      "args": "STAT=stat,ERRMSG=errmsg",
+      "doc": "Performs a synchronization of all images in the current team."
+    },
+    "SYNC IMAGES": {
+      "args": "image_set,STAT=stat,ERRMSG=errmsg",
+      "doc": "Performs a synchronization of the image with each of the other images in the image set."
+    },
+    "SYNC MEMORY": {
+      "args": "STAT=stat,ERRMSG=errmsg",
+      "doc": "Ends one image segment and begins another. Each segment can then be ordered in some way with respect to segments on other images."
+    },
+    "SYNC TEAM": {
+      "args": "team_value,STAT=stat,ERRMSG=errmsg",
+      "doc": "Performs a synchronization of all images on the specified team."
+    },
+    "UNLOCK": {
+      "doc": "Causes a lock variable to become unlocked by an image."
+    },
+    "WAIT": {
+      "doc": "Performs a wait operation for a specified pending asynchronous data transfer operation."
     },
     "WRITE": {
-      "doc": "Transfer output data to external sequential, direct-access, or internal records."
+      "doc": "Transfers output data to external sequential, direct-access, or internal records."
     }
   }
 }

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -265,7 +265,7 @@ def test_comp():
     file_path = test_dir / "subdir" / "test_free.f90"
     string += comp_request(file_path, 10, 22)
     string += comp_request(file_path, 14, 27)
-    string += comp_request(file_path, 28, 14)
+    string += comp_request(file_path, 28, 15)
     file_path = test_dir / "subdir" / "test_fixed.f"
     string += comp_request(file_path, 15, 8)
     string += comp_request(file_path, 15, 21)


### PR DESCRIPTION
acc. to. Intel oneAPI Develeoper (p. 2246) for consistency. I left out the vendor specific keywords `AUTOMATIC` and  `STATIC`. 
Probably it is better to switch to a not vendor specific document for refernce for example `ISO_1539-1_Fortran_Standart_2018`