### PR TITLE
Autoupdate pip with `--user` permissions

### DIFF
--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -1764,6 +1764,7 @@ class LangServer:
                             "install",
                             "fortls",
                             "--upgrade",
+                            "--user",
                         ],
                         capture_output=True,
                     )


### PR DESCRIPTION
Fixes #163

Previously pip would try and install in the root directory, which in some OSs would lack permissions and cause the install process to fail.