### PR TITLE
Add usedforsecurity flag to md5 hashing

### DIFF
--- a/fortls/parse_fortran.py
+++ b/fortls/parse_fortran.py
@@ -872,7 +872,7 @@ class FortranFile:
             return "Could not read/decode file", None
         else:
             # Check if files are the same
-            hash = hashlib.md5(contents.encode("utf-8")).hexdigest()
+            hash = hashlib.md5(contents.encode("utf-8"), usedforsecurity=False).hexdigest()
             if hash == self.hash:
                 return None, False
 


### PR DESCRIPTION
This PR adds the usedforsecurity flag to the md5 hash call. On FIPS enabled machines the plain command leads to an error.
