### PR TITLE
Change python 3.11 in CI from dev to final release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Python 3.11 is released and available as a tag in github CI.

In my repo coverage fails but I think I don't have the keys to upload to coverage server.

Builds are successful.