### PR TITLE
feat: add JSON schema for fortls configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 omit =
     fortls/__init__.py
     fortls/version.py
+    fortls/schema.py
 
 [report]
 exclude_lines =

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Lint
         run: black --diff --check --verbose .
 
+      - name: Check schema is up to date
+        run: |
+          python3 -m fortls.schema
+          git diff --exit-code ./fortls/fortls.schema.json
+
   coverage:
     strategy:
       matrix:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           python-version: "3.x"
 
+      - uses: softprops/action-gh-release@master
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          files: ./fortls/fortls.schema.json
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Added
 
+- Added and create a schema for fortls configuration files
+  ([#204](https://github.com/gnikit/fortls/issues/204))
 - Added dependabot alers for PyPi
   ([#222](https://github.com/gnikit/fortls/issues/222))
 - Added `CITATION.cff` file to project roots

--- a/fortls/__init__.py
+++ b/fortls/__init__.py
@@ -20,13 +20,8 @@ def error_exit(error_str: str):
 
 
 def main():
-    #
     freeze_support()
     args = cli(__name__).parse_args()
-
-    if args.version:
-        print(__version__)
-        sys.exit(0)
 
     debug_server = (
         args.debug_diagnostics

--- a/fortls/fortls.schema.json
+++ b/fortls/fortls.schema.json
@@ -1,0 +1,187 @@
+{
+  "title": "fortls schema",
+  "description": "Schema for the fortls Fortran Language Server",
+  "type": "object",
+  "properties": {
+    "config": {
+      "title": "Config",
+      "description": "Configuration options file (default file name: .fortlsrc, other default supported names: .fortls.json, .fortls)",
+      "default": ".fortlsrc",
+      "type": "string"
+    },
+    "nthreads": {
+      "title": "Nthreads",
+      "description": "Number of threads to use during workspace initialization (default: 4)",
+      "default": 4,
+      "type": "integer"
+    },
+    "notify_init": {
+      "title": "Notify Init",
+      "description": "Send notification message when workspace initialization is complete",
+      "default": false,
+      "type": "boolean"
+    },
+    "incremental_sync": {
+      "title": "Incremental Sync",
+      "description": "Use incremental document synchronization (beta)",
+      "default": false,
+      "type": "boolean"
+    },
+    "sort_keywords": {
+      "title": "Sort Keywords",
+      "description": "Display variable keywords information, function/subroutine definitions, etc. in a consistent (sorted) manner default: no sorting, display code as is)",
+      "default": false,
+      "type": "boolean"
+    },
+    "disable_autoupdate": {
+      "title": "Disable Autoupdate",
+      "description": "fortls automatically checks PyPi for newer version and installs them.Use this option to disable the autoupdate feature.",
+      "default": false,
+      "type": "boolean"
+    },
+    "preserve_keyword_order": {
+      "title": "Preserve Keyword Order",
+      "description": "DEPRECATED, this is now the default. To sort use sort_keywords",
+      "default": false,
+      "type": "boolean"
+    },
+    "debug_log": {
+      "title": "Debug Log",
+      "description": "Generate debug log in project root folder",
+      "default": false,
+      "type": "boolean"
+    },
+    "source_dirs": {
+      "title": "Source Dirs",
+      "description": "Folders containing source files (default: set())",
+      "default": [],
+      "type": "array",
+      "items": {},
+      "uniqueItems": true
+    },
+    "incl_suffixes": {
+      "title": "Incl Suffixes",
+      "description": "Consider additional file extensions to the default (default: F,F77,F90,F95,F03,F08,FOR,FPP (lower & upper casing))",
+      "default": [],
+      "type": "array",
+      "items": {},
+      "uniqueItems": true
+    },
+    "excl_suffixes": {
+      "title": "Excl Suffixes",
+      "description": "Source file extensions to be excluded (default: set())",
+      "default": [],
+      "type": "array",
+      "items": {},
+      "uniqueItems": true
+    },
+    "excl_paths": {
+      "title": "Excl Paths",
+      "description": "Folders to exclude from parsing",
+      "default": [],
+      "type": "array",
+      "items": {},
+      "uniqueItems": true
+    },
+    "autocomplete_no_prefix": {
+      "title": "Autocomplete No Prefix",
+      "description": "Do not filter autocomplete results by variable prefix",
+      "default": false,
+      "type": "boolean"
+    },
+    "autocomplete_no_snippets": {
+      "title": "Autocomplete No Snippets",
+      "description": "Do not use snippets with place holders in autocomplete results",
+      "default": false,
+      "type": "boolean"
+    },
+    "autocomplete_name_only": {
+      "title": "Autocomplete Name Only",
+      "description": "Complete only the name of procedures and not the parameters",
+      "default": false,
+      "type": "boolean"
+    },
+    "lowercase_intrinsics": {
+      "title": "Lowercase Intrinsics",
+      "description": "Use lowercase for intrinsics and keywords in autocomplete requests",
+      "default": false,
+      "type": "boolean"
+    },
+    "use_signature_help": {
+      "title": "Use Signature Help",
+      "description": "Use signature help instead of subroutine/function snippets. This effectively sets --autocomplete_no_snippets",
+      "default": false,
+      "type": "boolean"
+    },
+    "variable_hover": {
+      "title": "Variable Hover",
+      "description": "DEPRECATED: This option is always on. Show hover information for variables",
+      "default": false,
+      "type": "boolean"
+    },
+    "hover_signature": {
+      "title": "Hover Signature",
+      "description": "Show signature information in hover for arguments ",
+      "default": false,
+      "type": "boolean"
+    },
+    "hover_language": {
+      "title": "Hover Language",
+      "description": "Language used for responses to hover requests a VSCode language id (default: fortran90)",
+      "default": "fortran90",
+      "type": "string"
+    },
+    "max_line_length": {
+      "title": "Max Line Length",
+      "description": "Maximum line length (default: -1)",
+      "default": -1,
+      "type": "integer"
+    },
+    "max_comment_line_length": {
+      "title": "Max Comment Line Length",
+      "description": "Maximum comment line length (default: -1)",
+      "default": -1,
+      "type": "integer"
+    },
+    "disable_diagnostics": {
+      "title": "Disable Diagnostics",
+      "description": "Disable diagnostics",
+      "default": false,
+      "type": "boolean"
+    },
+    "pp_suffixes": {
+      "title": "Pp Suffixes",
+      "description": "File extensions to be parsed ONLY for preprocessor commands (default: all uppercase source file suffixes)",
+      "default": [],
+      "type": "array",
+      "items": {},
+      "uniqueItems": true
+    },
+    "include_dirs": {
+      "title": "Include Dirs",
+      "description": "Folders containing preprocessor files with extensions PP_SUFFIXES.",
+      "default": [],
+      "type": "array",
+      "items": {},
+      "uniqueItems": true
+    },
+    "pp_defs": {
+      "title": "Pp Defs",
+      "description": "A dictionary with additional preprocessor definitions. Preprocessor definitions are normally included via INCLUDE_DIRS",
+      "default": {},
+      "type": "object"
+    },
+    "symbol_skip_mem": {
+      "title": "Symbol Skip Mem",
+      "description": "Do not include type members in document symbol results",
+      "default": false,
+      "type": "boolean"
+    },
+    "enable_code_actions": {
+      "title": "Enable Code Actions",
+      "description": "Enable experimental code actions (default: false)",
+      "default": false,
+      "type": "boolean"
+    }
+  }
+}

--- a/fortls/interface.py
+++ b/fortls/interface.py
@@ -4,6 +4,8 @@ import argparse
 import json
 import sys
 
+from fortls.version import __version__
+
 
 class SetAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
@@ -37,7 +39,8 @@ def cli(name: str = "fortls") -> argparse.ArgumentParser:
     parser.add_argument(
         "-v",
         "--version",
-        action="store_true",
+        action="version",
+        version=__version__,
         help="Print server version number and exit",
     )
     parser.add_argument(
@@ -225,6 +228,7 @@ def cli(name: str = "fortls") -> argparse.ArgumentParser:
     group.add_argument(
         "--pp_suffixes",
         type=str,
+        default=set(),
         nargs="*",
         metavar="SUFFIXES",
         help=(
@@ -246,6 +250,7 @@ def cli(name: str = "fortls") -> argparse.ArgumentParser:
         "--pp_defs",
         type=json.loads,
         default={},
+        metavar="JSON",
         help=(
             "A dictionary with additional preprocessor definitions. "
             "Preprocessor definitions are normally included via INCLUDE_DIRS"

--- a/fortls/schema.py
+++ b/fortls/schema.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pathlib
+
+from pydantic import Field, create_model
+
+from fortls.interface import cli
+
+
+def create_schema(root: pathlib.Path | None = None):
+    if not root:
+        root = pathlib.Path(__file__).parent
+
+    parser = cli("fortls")
+    only_vals = {}
+    for arg in parser._actions:
+        if (
+            arg.dest == "help"
+            or arg.dest == "version"
+            or arg.help == "==SUPPRESS=="
+            or (arg.dest.startswith("debug") and arg.dest != "debug_log")
+        ):
+            continue
+        val = arg.default
+        desc: str = arg.help.replace("%(default)s", str(val))  # type: ignore
+        only_vals[arg.dest] = Field(val, description=desc)  # type: ignore
+
+    m = create_model("fortls schema", **only_vals)
+    m.__doc__ = "Schema for the fortls Fortran Language Server"
+
+    with open(str(root / "fortls.schema.json"), "w") as f:
+        print(m.schema_json(indent=2), file=f)
+    print(f"Created schema file: {root / 'fortls.schema.json'}")
+
+
+if __name__ == "__main__":
+    create_schema()

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ dev =
     black
     isort
     pre-commit
+    pydantic
 docs =
     sphinx >= 4.0.0
     sphinx-argparse


### PR DESCRIPTION
Adds a JSON schema validator for the configuration options offered. The schema is autogenerated via the CLI.

It also changes how the version display happens.

Fixes #204 