### PR TITLE
Support parsing of compile_commands.json

### DIFF
--- a/fortls/compile_commands.py
+++ b/fortls/compile_commands.py
@@ -1,0 +1,252 @@
+"""Parse compile_commands.json (Clang Compilation Database) for fortls."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class CompileCommandsConfig:
+    """Configuration extracted from compile_commands.json."""
+
+    include_dirs: set[str] = field(default_factory=set)
+    pp_defs: dict[str, str] = field(default_factory=dict)
+    source_files: set[str] = field(default_factory=set)
+    file_to_module_dir: dict[str, str] = field(default_factory=dict)
+
+
+def find_compile_commands(root_path: str, custom_path: str | None = None) -> str | None:
+    """Search for compile_commands.json.
+
+    Search order:
+    1. custom_path (if provided)
+    2. root_path/compile_commands.json
+    3. root_path/build/compile_commands.json
+    4. root_path/builddir/compile_commands.json
+    5. Recursive search in subdirectories
+    """
+    if custom_path:
+        if os.path.isabs(custom_path):
+            check_path = custom_path
+        else:
+            check_path = os.path.join(root_path, custom_path)
+        if os.path.isfile(check_path):
+            return os.path.abspath(check_path)
+        log.warning("Specified compile_commands.json not found: %s", custom_path)
+        return None
+
+    search_paths = [
+        os.path.join(root_path, "compile_commands.json"),
+        os.path.join(root_path, "build", "compile_commands.json"),
+        os.path.join(root_path, "builddir", "compile_commands.json"),
+    ]
+
+    for path in search_paths:
+        if os.path.isfile(path):
+            return os.path.abspath(path)
+
+    # Recursive search for projects in subdirectories
+    for root, dirs, files in os.walk(root_path):
+        dirs[:] = [
+            d
+            for d in dirs
+            if not d.startswith(".") and d not in ("node_modules", "__pycache__")
+        ]
+        if "compile_commands.json" in files:
+            return os.path.abspath(os.path.join(root, "compile_commands.json"))
+
+    return None
+
+
+def parse_compile_commands(
+    path: str, root_path: str | None = None
+) -> CompileCommandsConfig:
+    """Parse compile_commands.json and extract configuration."""
+    config = CompileCommandsConfig()
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            entries = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        log.error("Failed to parse compile_commands.json: %s", e)
+        return config
+
+    if not isinstance(entries, list):
+        log.error("compile_commands.json must contain a JSON array")
+        return config
+
+    # Map basenames to workspace paths for path normalization
+    workspace_files: dict[str, str] = {}
+    if root_path:
+        build_dir = os.path.dirname(path)
+        for root, _, files in os.walk(root_path):
+            if build_dir and root.startswith(build_dir):
+                continue
+            for f in files:
+                if "-pp.f90" in f.lower() or "-pp.f" in f.lower():
+                    continue
+                if _is_fortran_file(f):
+                    workspace_files[f] = os.path.join(root, f)
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+
+        directory = entry.get("directory", "")
+        source_file = _normalize_source_path(
+            entry.get("file", ""), directory, root_path, workspace_files
+        )
+
+        if source_file:
+            config.source_files.add(source_file)
+
+        args = _get_arguments(entry)
+        if args is None:
+            continue
+
+        inc_dirs, defines, module_dir = _parse_compiler_args(args, directory)
+        config.include_dirs.update(inc_dirs)
+
+        for name, value in defines.items():
+            if name not in config.pp_defs:
+                config.pp_defs[name] = value
+
+        if source_file and module_dir:
+            config.file_to_module_dir[source_file] = module_dir
+
+    log.info(
+        "Loaded compile_commands.json: %d include dirs, %d defines, %d files",
+        len(config.include_dirs),
+        len(config.pp_defs),
+        len(config.source_files),
+    )
+
+    return config
+
+
+def _is_fortran_file(filename: str) -> bool:
+    """Check if filename has a Fortran extension."""
+    return filename.endswith(
+        (".f90", ".F90", ".f", ".F", ".f95", ".F95", ".f03", ".F03", ".f08", ".F08")
+    )
+
+
+def _normalize_source_path(
+    source_file: str,
+    directory: str,
+    root_path: str | None,
+    workspace_files: dict[str, str],
+) -> str | None:
+    """Normalize source file path, falling back to basename lookup."""
+    if not source_file:
+        return None
+
+    if not os.path.isabs(source_file):
+        source_file = os.path.join(directory, source_file)
+
+    source_file = os.path.normpath(source_file)
+
+    if root_path and not os.path.exists(source_file):
+        basename = os.path.basename(source_file)
+        if basename in workspace_files:
+            source_file = workspace_files[basename]
+
+    return source_file
+
+
+def _get_arguments(entry: dict) -> list | None:
+    """Extract arguments from compile_commands entry."""
+    if "arguments" in entry:
+        args = entry["arguments"]
+        return args if isinstance(args, list) else None
+    elif "command" in entry:
+        try:
+            return shlex.split(entry["command"])
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_compiler_args(
+    args: list, directory: str
+) -> tuple[set[str], dict[str, str], str | None]:
+    """Parse compiler arguments for include dirs, defines, and module dir."""
+    include_dirs: set[str] = set()
+    pp_defs: dict[str, str] = {}
+    module_dir: str | None = None
+
+    i = 0
+    while i < len(args):
+        arg = args[i]
+
+        if arg.startswith("-I"):
+            path = _extract_flag_value(arg, "-I", args, i)
+            if path is not None:
+                if arg == "-I":
+                    i += 1
+                resolved = _resolve_path(path, directory)
+                if resolved:
+                    include_dirs.add(resolved)
+
+        elif arg.startswith("-J"):
+            path = _extract_flag_value(arg, "-J", args, i)
+            if path is not None:
+                if arg == "-J":
+                    i += 1
+                resolved = _resolve_path(path, directory)
+                if resolved:
+                    include_dirs.add(resolved)
+                    module_dir = resolved
+
+        elif arg == "-module" and i + 1 < len(args):
+            path = args[i + 1]
+            i += 1
+            resolved = _resolve_path(path, directory)
+            if resolved:
+                include_dirs.add(resolved)
+                module_dir = resolved
+
+        elif arg.startswith("-D"):
+            define = _extract_flag_value(arg, "-D", args, i)
+            if define is not None:
+                if arg == "-D":
+                    i += 1
+                name, value = _parse_define(define)
+                if name:
+                    pp_defs[name] = value
+
+        i += 1
+
+    return include_dirs, pp_defs, module_dir
+
+
+def _extract_flag_value(arg: str, flag: str, args: list, index: int) -> str | None:
+    """Extract value from -Xvalue or -X value format."""
+    if arg == flag:
+        return args[index + 1] if index + 1 < len(args) else None
+    return arg[len(flag) :]
+
+
+def _resolve_path(path: str, directory: str) -> str | None:
+    """Resolve path relative to directory."""
+    if not path:
+        return None
+    if not os.path.isabs(path):
+        path = os.path.join(directory, path)
+    return os.path.normpath(path)
+
+
+def _parse_define(define: str) -> tuple[str, str]:
+    """Parse preprocessor definition into (name, value)."""
+    if not define:
+        return ("", "")
+    if "=" in define:
+        name, value = define.split("=", 1)
+        return (name.strip(), value)
+    return (define.strip(), "True")

--- a/fortls/compile_commands.py
+++ b/fortls/compile_commands.py
@@ -98,7 +98,20 @@ def parse_compile_commands(
             for f in files:
                 if "-pp.f90" in f.lower() or "-pp.f" in f.lower():
                     continue
-                if _is_fortran_file(f):
+                if f.endswith(
+                    (
+                        ".f90",
+                        ".F90",
+                        ".f",
+                        ".F",
+                        ".f95",
+                        ".F95",
+                        ".f03",
+                        ".F03",
+                        ".f08",
+                        ".F08",
+                    )
+                ):
                     workspace_files[f] = str(Path(root) / f)
 
     for entry in entries:
@@ -135,13 +148,6 @@ def parse_compile_commands(
     )
 
     return config
-
-
-def _is_fortran_file(filename: str) -> bool:
-    """Check if filename has a Fortran extension."""
-    return filename.endswith(
-        (".f90", ".F90", ".f", ".F", ".f95", ".F95", ".f03", ".F03", ".f08", ".F08")
-    )
 
 
 def _normalize_source_path(
@@ -225,7 +231,12 @@ def _parse_compiler_args(
             if define is not None:
                 if arg == "-D":
                     i += 1
-                name, value = _parse_define(define)
+                # Parse define: NAME or NAME=VALUE
+                if "=" in define:
+                    name, value = define.split("=", 1)
+                    name = name.strip()
+                else:
+                    name, value = define.strip(), "True"
                 if name:
                     pp_defs[name] = value
 
@@ -249,13 +260,3 @@ def _resolve_path(path: str, directory: str) -> str | None:
     if not resolved.is_absolute():
         resolved = Path(directory) / resolved
     return str(_normpath(resolved))
-
-
-def _parse_define(define: str) -> tuple[str, str]:
-    """Parse preprocessor definition into (name, value)."""
-    if not define:
-        return ("", "")
-    if "=" in define:
-        name, value = define.split("=", 1)
-        return (name.strip(), value)
-    return (define.strip(), "True")

--- a/fortls/fortls.schema.json
+++ b/fortls/fortls.schema.json
@@ -87,6 +87,18 @@
       "type": "array",
       "uniqueItems": true
     },
+    "compile_commands": {
+      "default": null,
+      "description": "Path to compile_commands.json for automatic configuration of include directories and preprocessor definitions. Auto-detected in build/ if not specified.",
+      "title": "Compile Commands",
+      "type": ["string", "null"]
+    },
+    "disable_compile_commands": {
+      "default": false,
+      "description": "Disable auto-detection and use of compile_commands.json",
+      "title": "Disable Compile Commands",
+      "type": "boolean"
+    },
     "autocomplete_no_prefix": {
       "default": false,
       "description": "Do not filter autocomplete results by variable prefix",

--- a/fortls/interface.py
+++ b/fortls/interface.py
@@ -154,6 +154,22 @@ def cli(name: str = "fortls") -> argparse.ArgumentParser:
         metavar="DIRS",
         help="Folders to exclude from parsing",
     )
+    group.add_argument(
+        "--compile_commands",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to compile_commands.json for automatic configuration of "
+            "include directories and preprocessor definitions. Auto-detected "
+            "in build/ if not specified."
+        ),
+    )
+    group.add_argument(
+        "--disable_compile_commands",
+        action="store_true",
+        help="Disable auto-detection and use of compile_commands.json",
+    )
 
     # Autocomplete options -----------------------------------------------------
     group = parser.add_argument_group("Autocomplete options")

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -1701,9 +1701,10 @@ class LangServer:
         self.compile_commands_source_files = config.source_files
 
         # Exclude build directory to avoid preprocessed files
-        build_dir = os.path.dirname(cc_path)
-        if build_dir and build_dir != self.root_path:
-            self.excl_paths.add(build_dir)
+        build_dir = Path(cc_path).parent
+        build_dir_str = str(build_dir)
+        if build_dir_str and build_dir_str != self.root_path:
+            self.excl_paths.add(build_dir_str)
 
     def _resolve_globs_in_paths(self) -> None:
         """Resolves glob patterns in `excl_paths`, `source_dirs` and `include_dirs`.
@@ -1884,15 +1885,16 @@ class LangServer:
             return self.file_to_module_dir[filepath]
 
         try:
-            normalized = os.path.realpath(filepath)
+            path_obj = Path(filepath)
+            normalized = str(path_obj.resolve(strict=False))
             if normalized in self.file_to_module_dir:
                 return self.file_to_module_dir[normalized]
 
-            basename = os.path.basename(filepath)
+            basename = path_obj.name
             for stored_path, module_dir in self.file_to_module_dir.items():
-                if os.path.basename(stored_path) == basename:
+                if Path(stored_path).name == basename:
                     try:
-                        if os.path.samefile(filepath, stored_path):
+                        if path_obj.samefile(stored_path):
                             return module_dir
                     except OSError:
                         pass

--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -16,6 +16,8 @@ from urllib.error import URLError
 import json5
 from packaging import version
 
+from fortls.compile_commands import find_compile_commands, parse_compile_commands
+
 # Local modules
 from fortls.constants import (
     CLASS_TYPE_ID,
@@ -75,7 +77,9 @@ class LangServer:
         self.running: bool = True
         self.root_path: str = None
         self.workspace: dict[str, FortranFile] = {}
-        self.obj_tree: dict = {}
+        self.obj_tree: dict = {}  # {key: [[obj, filepath], ...]}
+        self.file_to_module_dir: dict[str, str] = {}  # For compile_commands grouping
+        self.compile_commands_source_files: set[str] = set()
         self.link_version = 0
         self._version = version.parse(__version__)
         # Parse a dictionary of the command line interface and make them into
@@ -198,6 +202,7 @@ class LangServer:
         self.source_dirs.add(self.root_path)
 
         self._load_config_file()
+        self._load_compile_commands()
         update_recursion_limit(self.recursion_limit)
         self._resolve_globs_in_paths()
         self._config_logger(request)
@@ -433,7 +438,7 @@ class LangServer:
             import_var_list = []
             for use_mod, use_info in use_dict.items():
                 if type(use_info) is Use:
-                    scope = self.obj_tree[use_mod][0]
+                    scope = self.obj_tree[use_mod][0][0]
                     only_list = use_info.rename()
                     tmp_list = child_candidates(
                         scope, only_list, req_abstract=abstract_only
@@ -463,7 +468,7 @@ class LangServer:
 
             # Add globals
             if inc_globals:
-                tmp_list = [obj[0] for (_, obj) in self.obj_tree.items()]
+                tmp_list = [entries[0][0] for (_, entries) in self.obj_tree.items()]
                 var_list += tmp_list + self.intrinsic_funs
                 rename_list += [None for _ in tmp_list + self.intrinsic_funs]
             if import_var_list:
@@ -587,7 +592,7 @@ class LangServer:
         if line_context == "mod_only":
             # Module names only (USE statement)
             for key in self.obj_tree:
-                candidate = self.obj_tree[key][0]
+                candidate = self.obj_tree[key][0][0]
                 if (
                     candidate.get_type() == MODULE_TYPE_ID
                 ) and candidate.name.lower().startswith(var_prefix):
@@ -598,7 +603,7 @@ class LangServer:
             name_only = True
             mod_name = context_info.lower()
             if mod_name in self.obj_tree:
-                scope_list = [self.obj_tree[mod_name][0]]
+                scope_list = [self.obj_tree[mod_name][0][0]]
                 public_only = True
                 include_globals = False
                 type_mask[CLASS_TYPE_ID] = False
@@ -793,15 +798,22 @@ class LangServer:
             ):
                 curr_scope = curr_scope.parent
             var_obj = find_in_scope(
-                curr_scope, def_name, self.obj_tree, var_line_number=def_line + 1
+                curr_scope,
+                def_name,
+                self.obj_tree,
+                var_line_number=def_line + 1,
+                obj_tree_getter=lambda key: self._get_from_obj_tree(
+                    key, def_file.path
+                ),  # Create a getter that uses the requesting file for disambiguation
             )
         # Search in global scope
         if var_obj is None:
             if is_member:
                 return None
             key = def_name.lower()
-            if key in self.obj_tree:
-                return self.obj_tree[key][0]
+            obj = self._get_from_obj_tree(key, def_file.path)
+            if obj is not None:
+                return obj
             for obj in self.intrinsic_funs:
                 if obj.name.lower() == key:
                     return obj
@@ -905,13 +917,17 @@ class LangServer:
         # Find in available scopes
         var_obj = None
         if curr_scope is not None:
-            var_obj = find_in_scope(curr_scope, sub_name, self.obj_tree)
+            var_obj = find_in_scope(
+                curr_scope,
+                sub_name,
+                self.obj_tree,
+                obj_tree_getter=lambda key: self._get_from_obj_tree(key, path),
+            )
         # Search in global scope
         if var_obj is None:
             key = sub_name.lower()
-            if key in self.obj_tree:
-                var_obj = self.obj_tree[key][0]
-            else:
+            var_obj = self._get_from_obj_tree(key, path)
+            if var_obj is None:
                 for obj in self.intrinsic_funs:
                     if obj.name.lower() == key:
                         var_obj = obj
@@ -1349,7 +1365,7 @@ class LangServer:
                 ast_old = file_obj.ast
                 if ast_old is not None:
                     for key in ast_old.global_dict:
-                        self.obj_tree.pop(key, None)
+                        self._remove_from_obj_tree(key, filepath)
             return
         did_change, err_str = self.update_workspace_file(
             filepath, read_file=True, allow_empty=did_open
@@ -1410,14 +1426,14 @@ class LangServer:
         ast_old = file_obj.ast
         if ast_old is not None:
             for key in ast_old.global_dict:
-                self.obj_tree.pop(key, None)
+                self._remove_from_obj_tree(key, filepath)
         # Add new file to workspace
         file_obj.ast = ast_new
         if filepath not in self.workspace:
             self.workspace[filepath] = file_obj
         # Add top-level objects to object tree
         for key, obj in ast_new.global_dict.items():
-            self.obj_tree[key] = [obj, filepath]
+            self._add_to_obj_tree(key, obj, filepath)
         # Update local links/inheritance if necessary
         if update_links:
             self.link_version = (self.link_version + 1) % 1000
@@ -1507,7 +1523,7 @@ class LangServer:
             # Add top-level objects to object tree
             ast_new = self.workspace[path].ast
             for key in ast_new.global_dict:
-                self.obj_tree[key] = [ast_new.global_dict[key], path]
+                self._add_to_obj_tree(key, ast_new.global_dict[key], path)
         # Update include statements
         for _, file_obj in self.workspace.items():
             file_obj.ast.resolve_includes(self.workspace)
@@ -1593,6 +1609,13 @@ class LangServer:
         # Update the source file REGEX
         self.FORTRAN_SRC_EXT_REGEX = create_src_file_exts_str(self.incl_suffixes)
         self.excl_suffixes = set(config_dict.get("excl_suffixes", self.excl_suffixes))
+        # compile_commands.json options
+        self.compile_commands = config_dict.get(
+            "compile_commands", getattr(self, "compile_commands", None)
+        )
+        self.disable_compile_commands = config_dict.get(
+            "disable_compile_commands", getattr(self, "disable_compile_commands", False)
+        )
 
     def _load_config_file_general(self, config_dict: dict) -> None:
         # General options ------------------------------------------------------
@@ -1654,6 +1677,34 @@ class LangServer:
 
         self.include_dirs = set(config_dict.get("include_dirs", self.include_dirs))
 
+    def _load_compile_commands(self) -> None:
+        """Load configuration from compile_commands.json if present."""
+        if getattr(self, "disable_compile_commands", False):
+            return
+
+        cc_path = find_compile_commands(
+            self.root_path, getattr(self, "compile_commands", None)
+        )
+        if cc_path is None:
+            return
+
+        log.info("Loading compile_commands.json from: %s", cc_path)
+        config = parse_compile_commands(cc_path, self.root_path)
+
+        self.include_dirs = self.include_dirs | config.include_dirs
+
+        merged_pp_defs = config.pp_defs.copy()
+        merged_pp_defs.update(self.pp_defs)
+        self.pp_defs = merged_pp_defs
+
+        self.file_to_module_dir = config.file_to_module_dir
+        self.compile_commands_source_files = config.source_files
+
+        # Exclude build directory to avoid preprocessed files
+        build_dir = os.path.dirname(cc_path)
+        if build_dir and build_dir != self.root_path:
+            self.excl_paths.add(build_dir)
+
     def _resolve_globs_in_paths(self) -> None:
         """Resolves glob patterns in `excl_paths`, `source_dirs` and `include_dirs`.
         Also performs the exclusion of `excl_paths` from `source_dirs`.
@@ -1688,6 +1739,14 @@ class LangServer:
         source files only if the option `source_dirs` has not been specified
         in the configuration file or no configuration file is present
         """
+
+        def is_excluded(path: str) -> bool:
+            """Check if path is in or under any excluded path"""
+            for excl in self.excl_paths:
+                if path == excl or path.startswith(excl + os.sep):
+                    return True
+            return False
+
         # Recursively add sub-directories that only match Fortran extensions
         if len(self.source_dirs) != 1:
             return None
@@ -1695,10 +1754,14 @@ class LangServer:
             return None
         self.source_dirs = set()
         for root, dirs, files in os.walk(self.root_path):
+            # Skip excluded directories and their subdirectories
+            if is_excluded(root):
+                dirs[:] = []  # Don't descend into subdirectories
+                continue
             # Match not found
             if not list(filter(self.FORTRAN_SRC_EXT_REGEX.search, files)):
                 continue
-            if root not in self.source_dirs and root not in self.excl_paths:
+            if root not in self.source_dirs:
                 self.source_dirs.add(str(Path(root).resolve()))
 
     def _get_source_files(self) -> list[str]:
@@ -1765,7 +1828,7 @@ class LangServer:
             self.intrinsic_mods,
         ) = load_intrinsics()
         for module in self.intrinsic_mods:
-            self.obj_tree[module.FQSN] = [module, None]
+            self._add_to_obj_tree(module.FQSN, module, None)
         # Set object settings
         set_keyword_ordering(self.sort_keywords)
 
@@ -1776,6 +1839,67 @@ class LangServer:
         if schar < 0:
             schar = echar = 0
         return uri_json(path_to_uri(obj_file.path), sline, schar, sline, echar)
+
+    def _add_to_obj_tree(self, key: str, obj, filepath: str) -> None:
+        """Add an object to obj_tree (supports multiple objects with same key)."""
+        if key not in self.obj_tree:
+            self.obj_tree[key] = []
+        self.obj_tree[key].append([obj, filepath])
+
+    def _remove_from_obj_tree(self, key: str, filepath: str) -> None:
+        """Remove objects from obj_tree that belong to a specific file."""
+        if key not in self.obj_tree:
+            return
+        self.obj_tree[key] = [
+            entry for entry in self.obj_tree[key] if entry[1] != filepath
+        ]
+        if not self.obj_tree[key]:
+            del self.obj_tree[key]
+
+    def _get_from_obj_tree(self, key: str, requesting_filepath: str = None):
+        """Get object from obj_tree, preferring same compilation unit if ambiguous."""
+        if key not in self.obj_tree:
+            return None
+        entries = self.obj_tree[key]
+        if not entries:
+            return None
+
+        if len(entries) == 1 or requesting_filepath is None:
+            return entries[0][0]
+
+        req_module_dir = self._get_module_dir_for_file(requesting_filepath)
+        if req_module_dir:
+            for obj, obj_filepath in entries:
+                if self._get_module_dir_for_file(obj_filepath) == req_module_dir:
+                    return obj
+
+        return entries[0][0]
+
+    def _get_module_dir_for_file(self, filepath: str) -> str | None:
+        """Get module directory for a file from compile_commands.json info."""
+        if not filepath or not self.file_to_module_dir:
+            return None
+
+        if filepath in self.file_to_module_dir:
+            return self.file_to_module_dir[filepath]
+
+        try:
+            normalized = os.path.realpath(filepath)
+            if normalized in self.file_to_module_dir:
+                return self.file_to_module_dir[normalized]
+
+            basename = os.path.basename(filepath)
+            for stored_path, module_dir in self.file_to_module_dir.items():
+                if os.path.basename(stored_path) == basename:
+                    try:
+                        if os.path.samefile(filepath, stored_path):
+                            return module_dir
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+
+        return None
 
     def _update_version_pypi(self, test: bool = False):
         """Fetch updates from PyPi for fortls

--- a/fortls/parsers/internal/submodule.py
+++ b/fortls/parsers/internal/submodule.py
@@ -51,7 +51,7 @@ class Submodule(Module):
         if not self.ancestor_name:
             return
         if self.ancestor_name in obj_tree:
-            self.ancestor_obj = obj_tree[self.ancestor_name][0][0]
+            self.ancestor_obj, _ = obj_tree[self.ancestor_name][0]
 
     def require_inherit(self):
         return True

--- a/fortls/parsers/internal/submodule.py
+++ b/fortls/parsers/internal/submodule.py
@@ -51,7 +51,7 @@ class Submodule(Module):
         if not self.ancestor_name:
             return
         if self.ancestor_name in obj_tree:
-            self.ancestor_obj = obj_tree[self.ancestor_name][0]
+            self.ancestor_obj = obj_tree[self.ancestor_name][0][0]
 
     def require_inherit(self):
         return True

--- a/fortls/parsers/internal/utilities.py
+++ b/fortls/parsers/internal/utilities.py
@@ -12,6 +12,15 @@ if TYPE_CHECKING:
     from .scope import Scope
 
 
+def _get_obj_from_tree(key: str, obj_tree: dict, obj_tree_getter=None):
+    """Get object from obj_tree, using getter if provided for disambiguation."""
+    if obj_tree_getter is not None:
+        return obj_tree_getter(key)
+    if key in obj_tree and obj_tree[key]:
+        return obj_tree[key][0].obj
+    return None
+
+
 def get_use_tree(
     scope: Scope,
     use_dict: dict[str, Use | Import],
@@ -27,13 +36,6 @@ def get_use_tree(
         rename_map = {}
     if curr_path is None:
         curr_path = []
-
-    def get_obj_from_tree(key: str):
-        if obj_tree_getter is not None:
-            return obj_tree_getter(key)
-        if key in obj_tree and obj_tree[key]:
-            return obj_tree[key][0][0]
-        return None
 
     def intersect_only(use_stmnt: Use | Import):
         tmp_list = []
@@ -119,7 +121,7 @@ def get_use_tree(
         if type(use_stmnt) is Import:
             continue
         # Descend USE tree
-        mod_obj = get_obj_from_tree(use_stmnt.mod_name)
+        mod_obj = _get_obj_from_tree(use_stmnt.mod_name, obj_tree, obj_tree_getter)
         if mod_obj is None:
             continue
         use_dict = get_use_tree(
@@ -144,13 +146,6 @@ def find_in_scope(
     obj_tree_getter=None,
 ):
     from .include import Include
-
-    def get_obj_from_tree(key: str):
-        if obj_tree_getter is not None:
-            return obj_tree_getter(key)
-        if key in obj_tree and obj_tree[key]:
-            return obj_tree[key][0][0]
-        return None
 
     def check_scope(
         local_scope: Scope,
@@ -226,7 +221,7 @@ def find_in_scope(
         # If use_mod is Import then it will not exist in the obj_tree
         if type(use_info) is Import:
             continue
-        use_scope = get_obj_from_tree(use_mod)
+        use_scope = _get_obj_from_tree(use_mod, obj_tree, obj_tree_getter)
         if use_scope is None:
             continue
         # Module name is request

--- a/fortls/parsers/internal/utilities.py
+++ b/fortls/parsers/internal/utilities.py
@@ -275,9 +275,8 @@ def find_in_workspace(
     matching_symbols = []
     query = query.lower()
     for _, entries in obj_tree.items():
-        # entries is a list of [obj, filepath] pairs; use first entry
-        top_obj = entries[0][0]
-        top_uri = entries[0][1]
+        # entries is a list of ObjTreeEntry(obj, filepath); use first entry
+        top_obj, top_uri = entries[0]
         if top_uri is not None:
             if top_obj.name.lower().find(query) > -1:
                 matching_symbols.append(top_obj)

--- a/fortls/parsers/internal/utilities.py
+++ b/fortls/parsers/internal/utilities.py
@@ -293,12 +293,14 @@ def find_in_workspace(
     return matching_symbols
 
 
-def climb_type_tree(var_stack, curr_scope: Scope, obj_tree: dict):
+def climb_type_tree(var_stack, curr_scope: Scope, obj_tree: dict, obj_tree_getter=None):
     """Walk up user-defined type sequence to determine final field type"""
     # Find base variable in current scope
     iVar = 0
     var_name = var_stack[iVar].strip().lower()
-    var_obj = find_in_scope(curr_scope, var_name, obj_tree)
+    var_obj = find_in_scope(
+        curr_scope, var_name, obj_tree, obj_tree_getter=obj_tree_getter
+    )
     if var_obj is None:
         return None
     # Search for type, then next variable in stack and so on
@@ -314,7 +316,13 @@ def climb_type_tree(var_stack, curr_scope: Scope, obj_tree: dict):
             break
         # Find next variable by name in type
         var_name = var_stack[iVar].strip().lower()
-        var_obj = find_in_scope(type_obj, var_name, obj_tree, local_only=True)
+        var_obj = find_in_scope(
+            type_obj,
+            var_name,
+            obj_tree,
+            local_only=True,
+            obj_tree_getter=obj_tree_getter,
+        )
         # Return if not found
         if var_obj is None:
             return None

--- a/test/test_compile_commands.py
+++ b/test/test_compile_commands.py
@@ -10,39 +10,35 @@ from setup_tests import run_request, test_dir, write_rpc_request
 
 from fortls.compile_commands import (
     _parse_compiler_args,
-    _parse_define,
     find_compile_commands,
     parse_compile_commands,
 )
 
 
 class TestParseDefine:
-    """Tests for _parse_define function"""
+    """Tests for define parsing (via _parse_compiler_args)"""
 
     def test_simple_define(self):
-        name, value = _parse_define("DEBUG")
-        assert name == "DEBUG"
-        assert value == "True"
+        _, pp_defs, _ = _parse_compiler_args(["gfortran", "-DDEBUG"], "/home")
+        assert pp_defs["DEBUG"] == "True"
 
     def test_define_with_value(self):
-        name, value = _parse_define("VERSION=1.0")
-        assert name == "VERSION"
-        assert value == "1.0"
+        _, pp_defs, _ = _parse_compiler_args(["gfortran", "-DVERSION=1.0"], "/home")
+        assert pp_defs["VERSION"] == "1.0"
 
     def test_define_with_quoted_value(self):
-        name, value = _parse_define('STR="hello world"')
-        assert name == "STR"
-        assert value == '"hello world"'
+        _, pp_defs, _ = _parse_compiler_args(
+            ["gfortran", '-DSTR="hello world"'], "/home"
+        )
+        assert pp_defs["STR"] == '"hello world"'
 
     def test_define_with_equals_in_value(self):
-        name, value = _parse_define("EXPR=a=b")
-        assert name == "EXPR"
-        assert value == "a=b"
+        _, pp_defs, _ = _parse_compiler_args(["gfortran", "-DEXPR=a=b"], "/home")
+        assert pp_defs["EXPR"] == "a=b"
 
-    def test_empty_define(self):
-        name, value = _parse_define("")
-        assert name == ""
-        assert value == ""
+    def test_no_define(self):
+        _, pp_defs, _ = _parse_compiler_args(["gfortran", "-c", "test.f90"], "/home")
+        assert len(pp_defs) == 0
 
 
 class TestParseCompilerArgs:

--- a/test/test_compile_commands.py
+++ b/test/test_compile_commands.py
@@ -1,0 +1,375 @@
+"""Tests for compile_commands.json parser"""
+
+from __future__ import annotations
+
+import json
+import os
+
+# Import the module under test
+import sys
+import tempfile
+from pathlib import Path
+
+from setup_tests import run_request, test_dir, write_rpc_request
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from fortls.compile_commands import (
+    _parse_compiler_args,
+    _parse_define,
+    find_compile_commands,
+    parse_compile_commands,
+)
+
+
+class TestParseDefine:
+    """Tests for _parse_define function"""
+
+    def test_simple_define(self):
+        name, value = _parse_define("DEBUG")
+        assert name == "DEBUG"
+        assert value == "True"
+
+    def test_define_with_value(self):
+        name, value = _parse_define("VERSION=1.0")
+        assert name == "VERSION"
+        assert value == "1.0"
+
+    def test_define_with_quoted_value(self):
+        name, value = _parse_define('STR="hello world"')
+        assert name == "STR"
+        assert value == '"hello world"'
+
+    def test_define_with_equals_in_value(self):
+        name, value = _parse_define("EXPR=a=b")
+        assert name == "EXPR"
+        assert value == "a=b"
+
+    def test_empty_define(self):
+        name, value = _parse_define("")
+        assert name == ""
+        assert value == ""
+
+
+class TestParseCompilerArgs:
+    """Tests for _parse_compiler_args function"""
+
+    def test_include_dir_attached(self):
+        """Test -Ipath format"""
+        args = ["gfortran", "-I/usr/include", "-c", "test.f90"]
+        inc_dirs, pp_defs, module_dir = _parse_compiler_args(args, "/home/user")
+        assert "/usr/include" in inc_dirs
+        assert len(pp_defs) == 0
+        assert module_dir is None
+
+    def test_include_dir_separate(self):
+        """Test -I path format (with space)"""
+        args = ["gfortran", "-I", "/usr/include", "-c", "test.f90"]
+        inc_dirs, *_ = _parse_compiler_args(args, "/home/user")
+        assert "/usr/include" in inc_dirs
+
+    def test_include_dir_relative(self):
+        """Test relative include path"""
+        args = ["gfortran", "-Iinclude", "-c", "test.f90"]
+        inc_dirs, *_ = _parse_compiler_args(args, "/home/user/project")
+        assert "/home/user/project/include" in inc_dirs
+
+    def test_module_dir_gfortran(self):
+        """Test -J flag (gfortran module directory)"""
+        args = ["gfortran", "-Jbuild/mod", "-c", "test.f90"]
+        inc_dirs, _, module_dir = _parse_compiler_args(args, "/home/user/project")
+        assert "/home/user/project/build/mod" in inc_dirs
+        assert module_dir == "/home/user/project/build/mod"
+
+    def test_module_dir_intel(self):
+        """Test -module flag (Intel Fortran)"""
+        args = ["ifort", "-module", "build/mod", "-c", "test.f90"]
+        inc_dirs, _, module_dir = _parse_compiler_args(args, "/home/user/project")
+        assert "/home/user/project/build/mod" in inc_dirs
+        assert module_dir == "/home/user/project/build/mod"
+
+    def test_preprocessor_define_simple(self):
+        """Test -DNAME format"""
+        args = ["gfortran", "-DDEBUG", "-c", "test.f90"]
+        _, pp_defs, _ = _parse_compiler_args(args, "/home/user")
+        assert pp_defs["DEBUG"] == "True"
+
+    def test_preprocessor_define_with_value(self):
+        """Test -DNAME=value format"""
+        args = ["gfortran", "-DVERSION=1.0", "-c", "test.f90"]
+        _, pp_defs, _ = _parse_compiler_args(args, "/home/user")
+        assert pp_defs["VERSION"] == "1.0"
+
+    def test_preprocessor_define_separate(self):
+        """Test -D NAME format (with space)"""
+        args = ["gfortran", "-D", "DEBUG", "-c", "test.f90"]
+        _, pp_defs, _ = _parse_compiler_args(args, "/home/user")
+        assert pp_defs["DEBUG"] == "True"
+
+    def test_multiple_flags(self):
+        """Test multiple -I and -D flags"""
+        args = [
+            "gfortran",
+            "-I/usr/include",
+            "-Ilib",
+            "-DDEBUG",
+            "-DVERSION=2",
+            "-c",
+            "test.f90",
+        ]
+        inc_dirs, pp_defs, _ = _parse_compiler_args(args, "/home/user/project")
+        assert "/usr/include" in inc_dirs
+        assert "/home/user/project/lib" in inc_dirs
+        assert pp_defs["DEBUG"] == "True"
+        assert pp_defs["VERSION"] == "2"
+
+
+class TestFindCompileCommands:
+    """Tests for find_compile_commands function"""
+
+    def test_custom_path_absolute(self):
+        """Test with absolute custom path"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cc_path = os.path.join(tmpdir, "my_compile_commands.json")
+            with open(cc_path, "w") as f:
+                json.dump([], f)
+            result = find_compile_commands("/some/root", cc_path)
+            assert result == cc_path
+
+    def test_custom_path_relative(self):
+        """Test with relative custom path"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cc_path = os.path.join(tmpdir, "custom.json")
+            with open(cc_path, "w") as f:
+                json.dump([], f)
+            result = find_compile_commands(tmpdir, "custom.json")
+            assert result == cc_path
+
+    def test_custom_path_not_found(self):
+        """Test with non-existent custom path"""
+        result = find_compile_commands("/tmp", "/nonexistent/path.json")
+        assert result is None
+
+    def test_root_path_detection(self):
+        """Test auto-detection in root path"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cc_path = os.path.join(tmpdir, "compile_commands.json")
+            with open(cc_path, "w") as f:
+                json.dump([], f)
+            result = find_compile_commands(tmpdir)
+            assert result == cc_path
+
+    def test_build_dir_detection(self):
+        """Test auto-detection in build/ subdirectory"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            build_dir = os.path.join(tmpdir, "build")
+            os.makedirs(build_dir)
+            cc_path = os.path.join(build_dir, "compile_commands.json")
+            with open(cc_path, "w") as f:
+                json.dump([], f)
+            result = find_compile_commands(tmpdir)
+            assert result == cc_path
+
+    def test_not_found(self):
+        """Test when no compile_commands.json exists"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = find_compile_commands(tmpdir)
+            assert result is None
+
+
+class TestParseCompileCommands:
+    """Tests for parse_compile_commands function"""
+
+    def test_cmake_format(self):
+        """Test parsing CMake-style compile_commands.json (command string)"""
+        cc_path = test_dir / "compile_commands" / "cmake_format.json"
+        config = parse_compile_commands(str(cc_path))
+
+        # Check include dirs
+        assert "/home/user/project/include" in config.include_dirs
+        assert "/home/user/project/src" in config.include_dirs
+        assert "/home/user/project/build/mod" in config.include_dirs
+
+        # Check preprocessor definitions
+        assert config.pp_defs["DEBUG"] == "1"
+        # Note: shlex.split() removes outer quotes from -DVERSION="1.0"
+        assert config.pp_defs["VERSION"] == "1.0"
+
+        # Check source files
+        assert "/home/user/project/src/main.f90" in config.source_files
+        assert "/home/user/project/src/module.f90" in config.source_files
+
+    def test_fpm_format(self):
+        """Test parsing fpm-style compile_commands.json (arguments array)"""
+        cc_path = test_dir / "compile_commands" / "fpm_format.json"
+        config = parse_compile_commands(str(cc_path))
+
+        # Check include dirs (should resolve relative to directory)
+        assert "/home/user/fpm_project/include" in config.include_dirs
+        assert "/home/user/fpm_project/build" in config.include_dirs
+
+        # Check preprocessor definitions
+        assert config.pp_defs["USE_MPI"] == "True"
+        assert config.pp_defs["APP_NAME"] == "myapp"
+
+        # Check source files (relative paths resolved)
+        assert "/home/user/fpm_project/src/module.f90" in config.source_files
+        assert "/home/user/fpm_project/app/main.f90" in config.source_files
+
+    def test_invalid_json(self):
+        """Test handling of invalid JSON file"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not valid json")
+            f.flush()
+            config = parse_compile_commands(f.name)
+            assert len(config.include_dirs) == 0
+            assert len(config.pp_defs) == 0
+            os.unlink(f.name)
+
+    def test_nonexistent_file(self):
+        """Test handling of non-existent file"""
+        config = parse_compile_commands("/nonexistent/path.json")
+        assert len(config.include_dirs) == 0
+        assert len(config.pp_defs) == 0
+
+    def test_empty_array(self):
+        """Test handling of empty compile_commands.json"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump([], f)
+            f.flush()
+            config = parse_compile_commands(f.name)
+            assert len(config.include_dirs) == 0
+            assert len(config.pp_defs) == 0
+            os.unlink(f.name)
+
+
+class TestIntegration:
+    """Integration tests with the language server"""
+
+    def test_server_with_compile_commands(self):
+        """Test that server loads compile_commands.json"""
+        # Create a temporary project with compile_commands.json
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create build directory with compile_commands.json
+            build_dir = os.path.join(tmpdir, "build")
+            os.makedirs(build_dir)
+            cc_path = os.path.join(build_dir, "compile_commands.json")
+
+            # Create a Fortran source file
+            src_file = os.path.join(tmpdir, "test.f90")
+            with open(src_file, "w") as f:
+                f.write("program test\nend program test\n")
+
+            # Create compile_commands.json with a preprocessor define
+            compile_commands = [
+                {
+                    "directory": tmpdir,
+                    "arguments": ["gfortran", "-DTEST_DEFINE=42", "-c", "test.f90"],
+                    "file": "test.f90",
+                }
+            ]
+            with open(cc_path, "w") as f:
+                json.dump(compile_commands, f)
+
+            # Initialize the server and check it works
+            string = write_rpc_request(1, "initialize", {"rootPath": tmpdir})
+            errcode, results = run_request(string)
+            assert errcode == 0
+            assert results[0]["capabilities"]["hoverProvider"] is True
+
+    def test_server_with_disabled_compile_commands(self):
+        """Test that --disable_compile_commands works"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create build directory with compile_commands.json
+            build_dir = os.path.join(tmpdir, "build")
+            os.makedirs(build_dir)
+            cc_path = os.path.join(build_dir, "compile_commands.json")
+
+            # Create a Fortran source file
+            src_file = os.path.join(tmpdir, "test.f90")
+            with open(src_file, "w") as f:
+                f.write("program test\nend program test\n")
+
+            # Create compile_commands.json
+            compile_commands = [
+                {
+                    "directory": tmpdir,
+                    "arguments": ["gfortran", "-c", "test.f90"],
+                    "file": "test.f90",
+                }
+            ]
+            with open(cc_path, "w") as f:
+                json.dump(compile_commands, f)
+
+            # Initialize the server with --disable_compile_commands
+            string = write_rpc_request(1, "initialize", {"rootPath": tmpdir})
+            errcode, _ = run_request(string, ["--disable_compile_commands"])
+            assert errcode == 0
+
+    def test_file_to_module_dir_mapping(self):
+        """Test that compile_commands.json extracts file to module dir mapping.
+
+        When files are compiled with different -J flags, the file_to_module_dir
+        mapping should group them correctly for disambiguation.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create directory structure
+            build_dir = os.path.join(tmpdir, "build")
+            mod1_dir = os.path.join(build_dir, "mod", "exe1")
+            mod2_dir = os.path.join(build_dir, "mod", "exe2")
+            os.makedirs(mod1_dir)
+            os.makedirs(mod2_dir)
+
+            exe1_path = os.path.join(tmpdir, "exe1.f90")
+            module1_path = os.path.join(tmpdir, "module1.f90")
+            exe2_path = os.path.join(tmpdir, "exe2.f90")
+            module2_path = os.path.join(tmpdir, "module2.f90")
+
+            # Create compile_commands.json that groups exe1+module1 and exe2+module2
+            compile_commands = [
+                {
+                    "directory": build_dir,
+                    "command": f"/usr/bin/f95 -J{mod1_dir} -c {exe1_path}",
+                    "file": exe1_path,
+                },
+                {
+                    "directory": build_dir,
+                    "command": f"/usr/bin/f95 -J{mod1_dir} -c {module1_path}",
+                    "file": module1_path,
+                },
+                {
+                    "directory": build_dir,
+                    "command": f"/usr/bin/f95 -J{mod2_dir} -c {exe2_path}",
+                    "file": exe2_path,
+                },
+                {
+                    "directory": build_dir,
+                    "command": f"/usr/bin/f95 -J{mod2_dir} -c {module2_path}",
+                    "file": module2_path,
+                },
+            ]
+            cc_path = os.path.join(build_dir, "compile_commands.json")
+            with open(cc_path, "w") as f:
+                json.dump(compile_commands, f)
+
+            # Parse the compile_commands.json
+            config = parse_compile_commands(cc_path)
+
+            # Verify file_to_module_dir mapping
+            assert exe1_path in config.file_to_module_dir
+            assert module1_path in config.file_to_module_dir
+            assert exe2_path in config.file_to_module_dir
+            assert module2_path in config.file_to_module_dir
+
+            # exe1 and module1 should share the same module dir
+            assert config.file_to_module_dir[exe1_path] == mod1_dir
+            assert config.file_to_module_dir[module1_path] == mod1_dir
+
+            # exe2 and module2 should share the same module dir
+            assert config.file_to_module_dir[exe2_path] == mod2_dir
+            assert config.file_to_module_dir[module2_path] == mod2_dir
+
+            # The two groups should have different module dirs
+            assert (
+                config.file_to_module_dir[exe1_path]
+                != config.file_to_module_dir[exe2_path]
+            )

--- a/test/test_source/compile_commands/cmake_format.json
+++ b/test/test_source/compile_commands/cmake_format.json
@@ -1,0 +1,12 @@
+[
+  {
+    "directory": "/home/user/project/build",
+    "command": "/usr/bin/gfortran -I/home/user/project/include -I/home/user/project/src -J/home/user/project/build/mod -DDEBUG=1 -DVERSION=1.0 -c /home/user/project/src/main.f90 -o main.o",
+    "file": "/home/user/project/src/main.f90"
+  },
+  {
+    "directory": "/home/user/project/build",
+    "command": "/usr/bin/gfortran -I/home/user/project/include -I/home/user/project/src -J/home/user/project/build/mod -DDEBUG=1 -DVERSION=1.0 -c /home/user/project/src/module.f90 -o module.o",
+    "file": "/home/user/project/src/module.f90"
+  }
+]

--- a/test/test_source/compile_commands/fpm_format.json
+++ b/test/test_source/compile_commands/fpm_format.json
@@ -1,0 +1,12 @@
+[
+  {
+    "directory": "/home/user/fpm_project",
+    "arguments": ["gfortran", "-Iinclude", "-Ibuild", "-DUSE_MPI", "-DAPP_NAME=myapp", "-c", "src/module.f90", "-o", "build/module.o"],
+    "file": "src/module.f90"
+  },
+  {
+    "directory": "/home/user/fpm_project",
+    "arguments": ["gfortran", "-Iinclude", "-Ibuild", "-DUSE_MPI", "-DAPP_NAME=myapp", "-c", "app/main.f90", "-o", "build/main.o"],
+    "file": "app/main.f90"
+  }
+]


### PR DESCRIPTION
Add support for parsing `compile_commands.json` to enable module disambiguation when multiple modules share the same name across different compilation units. This is a feature I wanted to have, prompted Claude Code to implement it and tested it to have the expected behavior.

Changes include:
- a new parser for `compile_commands.json` files, which extracts include directories (`-I`), module directories (`-J`/`-module`) and preprocessor definitions (`-D`)
- Module disambiguation: Uses `-J` flag mapping to group files by compilation unit, enabling correct "go to definition" when the same module name exists in different targets
- Configuration options:
  - `compile_commands`: Custom path to `compile_commands.json`
  - `disable_compile_commands`: Opt-out flag for projects that don't want this feature
- Auto-discovery: Searches `./`, `build/`, `builddir/` and recursively for `compile_commands.json` file

Internal changes
- `obj_tree` now stores multiple entries per key (as `ObjTreeEntry` namedtuples) to support duplicate module names
- Build directories are auto-excluded to avoid indexing preprocessed intermediate files

Closes #512.