### PR TITLE
Fixed the failing test

### DIFF
--- a/test/test_server_init.py
+++ b/test/test_server_init.py
@@ -9,7 +9,7 @@ from fortls.constants import Severity
 
 @pytest.fixture()
 def setup_tmp_file():
-    levels = 2000
+    levels = 20000
     fd, filename = tempfile.mkstemp(suffix=".f90")
     try:
         with os.fdopen(fd, "w") as tmp:


### PR DESCRIPTION
- This PR fixes #499

The internal management of nested structures (like the if blocks generated in the test fixture) has improved. A nesting level of 2,000 no longer triggers a RecursionError or a stack overflow. Because the server was successfully parsing the file instead of crashing it returned a capabilities object instead of the expected error object. Fixed it by increasing the nesting depth in test/test_server_init.py from 2,000 to 20,000.