### PR TITLE
Move global regex

### DIFF
--- a/fortls/langserver.py
+++ b/fortls/langserver.py
@@ -64,10 +64,6 @@ from fortls.parsers.internal.variable import Variable
 from fortls.regex_patterns import create_src_file_exts_str
 from fortls.version import __version__
 
-# Global regexes
-# TODO: I think this can be replaced by fortls.regex_patterns type & class
-TYPE_DEF_REGEX = re.compile(r"[ ]*(TYPE|CLASS)[ ]*\([a-z0-9_ ]*$", re.I)
-
 
 class LangServer:
     def __init__(self, conn, settings: dict):
@@ -788,7 +784,7 @@ class LangServer:
                         line_prefix.lstrip().lower().startswith("procedure")
                         and (line_prefix.count("=>") > 0)
                     )
-                    or TYPE_DEF_REGEX.match(line_prefix)
+                    or FRegex.TYPE_DEF_REGEX.match(line_prefix)
                 )
             ):
                 curr_scope = curr_scope.parent

--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -151,6 +151,9 @@ class FortranRegularExpressions:
     )
     # Object regex patterns
     CLASS_VAR: Pattern = compile(r"(TYPE|CLASS)[ ]*\(", I)
+    TYPE_DEF_REGEX: Pattern = compile(
+        r"\b(TYPE|CLASS)\s*\(\s*[a-zA-Z_][a-zA-Z0-9_]*\s*$", I
+    )
     DEF_KIND: Pattern = compile(r"(\w*)[ ]*\((?:KIND|LEN)?[ =]*(\w*)", I)
     OBJBREAK: Pattern = compile(r"[\/\-(.,+*<>=: ]", I)
 

--- a/test/test_server_definitions.py
+++ b/test/test_server_definitions.py
@@ -212,3 +212,18 @@ def test_def_function_implicit_result_variable():
     assert len(ref_res) == len(results) - 1
     for i, res in enumerate(ref_res):
         validate_def(results[i + 1], res)
+
+
+def test_type_def_regex_trigger():
+    """Ensure that TYPE(...) statements are correctly identified by regex
+    and that scope is adjusted to resolve the type definition.
+    """
+    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
+    file_path = test_dir / "subdir" / "test_free.f90"
+    string += def_request(file_path, 37, 10)
+    errcode, results = run_request(string)
+    assert errcode == 0
+    ref_res = [[8, 8, str(test_dir / "subdir" / "test_free.f90")]]
+    assert len(ref_res) == len(results) - 1
+    for i, res in enumerate(ref_res):
+        validate_def(results[i + 1], res)

--- a/test/test_server_definitions.py
+++ b/test/test_server_definitions.py
@@ -212,18 +212,3 @@ def test_def_function_implicit_result_variable():
     assert len(ref_res) == len(results) - 1
     for i, res in enumerate(ref_res):
         validate_def(results[i + 1], res)
-
-
-def test_type_def_regex_trigger():
-    """Ensure that TYPE(...) statements are correctly identified by regex
-    and that scope is adjusted to resolve the type definition.
-    """
-    string = write_rpc_request(1, "initialize", {"rootPath": str(test_dir)})
-    file_path = test_dir / "subdir" / "test_free.f90"
-    string += def_request(file_path, 37, 10)
-    errcode, results = run_request(string)
-    assert errcode == 0
-    ref_res = [[8, 8, str(test_dir / "subdir" / "test_free.f90")]]
-    assert len(ref_res) == len(results) - 1
-    for i, res in enumerate(ref_res):
-        validate_def(results[i + 1], res)


### PR DESCRIPTION
Moved global regex definitions from langserver.py to the dedicated regex_patterns module. This change centralizes regex handling, reduces duplication and aligns with the existing pattern management structure.