### PR TITLE
Fix include regex to support slash in paths

### DIFF
--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -133,7 +133,7 @@ class FortranRegularExpressions:
         I,
     )
     PP_DEF_TEST: Pattern = compile(r"(![ ]*)?defined[ ]*\([ ]*(\w*)[ ]*\)$", I)
-    PP_INCLUDE: Pattern = compile(r"[ ]*#[ ]*include[ ]*([\"\w\./]*)", I)
+    PP_INCLUDE: Pattern = compile(r"[ ]*#[ ]*include[ ]*[\"']([\w\./]+)[\"']", I)
     PP_ANY: Pattern = compile(r"^[ ]*#:?[ ]*(\w+)")
     # Context matching rules
     CALL: Pattern = compile(r"[ ]*CALL[ ]+[\w%]*$", I)

--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -133,7 +133,7 @@ class FortranRegularExpressions:
         I,
     )
     PP_DEF_TEST: Pattern = compile(r"(![ ]*)?defined[ ]*\([ ]*(\w*)[ ]*\)$", I)
-    PP_INCLUDE: Pattern = compile(r"[ ]*#[ ]*include[ ]*([\"\w\.]*)", I)
+    PP_INCLUDE: Pattern = compile(r"[ ]*#[ ]*include[ ]*([\"\w\./]*)", I)
     PP_ANY: Pattern = compile(r"^[ ]*#:?[ ]*(\w+)")
     # Context matching rules
     CALL: Pattern = compile(r"[ ]*CALL[ ]+[\w%]*$", I)

--- a/test/test_regex_patterns.py
+++ b/test/test_regex_patterns.py
@@ -44,3 +44,12 @@ def test_src_file_exts(
     regex = create_src_file_exts_regex(input_exts)
     results = [bool(regex.search(file)) for file in input_files]
     assert results == matches
+
+def test_include_with_slash():
+    from fortls.regex_patterns import FortranRegularExpressions
+
+    line = '#include "petsc/finclude/petscvec.h"'
+    match = FortranRegularExpressions.PP_INCLUDE.match(line)
+
+    assert match is not None
+    assert match.group(1) == "petsc/finclude/petscvec.h"

--- a/test/test_regex_patterns.py
+++ b/test/test_regex_patterns.py
@@ -45,6 +45,7 @@ def test_src_file_exts(
     results = [bool(regex.search(file)) for file in input_files]
     assert results == matches
 
+
 def test_include_with_slash():
     from fortls.regex_patterns import FortranRegularExpressions
 


### PR DESCRIPTION
## Fix include regex to support paths with slashes

### Problem
The regex for parsing `#include` statements does not correctly capture paths containing `/`.

Example:
#include "petsc/finclude/petscvec.h"

was parsed as:
petsc

### Solution
Updated regex to include `/` in the captured path.

### Changes
- Fixed regex in `regex_patterns.py`
- Added test for include paths with slashes

Fixes #481