### PR TITLE
CI : Added a condition for deploy

### DIFF
--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -31,6 +31,7 @@ jobs:
           pip install -e .[dev,docs]
           make -C docs html
       - name: Deploy Preview
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: rossjrw/pr-preview-action@v1.8.1
         with:
           source-dir: docs/_build/html


### PR DESCRIPTION
Docs preview deployment fails for forked PRs due to GitHub permission restrictions (403).
Added condition to skip deployment for fork PRs.

If fork previews are desired, this would require switching to pull_request_target or using a different deployment strategy.