### PR TITLE
Fix: Support directory slashes in preprocessor include regex (#481)

### DIFF
--- a/fortls/regex_patterns.py
+++ b/fortls/regex_patterns.py
@@ -133,7 +133,7 @@ class FortranRegularExpressions:
         I,
     )
     PP_DEF_TEST: Pattern = compile(r"(![ ]*)?defined[ ]*\([ ]*(\w*)[ ]*\)$", I)
-    PP_INCLUDE: Pattern = compile(r"[ ]*#[ ]*include[ ]*([\"\w\.]*)", I)
+    PP_INCLUDE: Pattern = compile(r"[ ]*#[ ]*include[ ]*([\"\w\./\\]*)", I)
     PP_ANY: Pattern = compile(r"^[ ]*#:?[ ]*(\w+)")
     # Context matching rules
     CALL: Pattern = compile(r"[ ]*CALL[ ]+[\w%]*$", I)

--- a/test/test_regex_patterns.py
+++ b/test/test_regex_patterns.py
@@ -46,20 +46,19 @@ def test_src_file_exts(
     assert results == matches
 
 
-
 def test_issue_481_include_with_slashes():
     """Test that preprocessor includes correctly capture directory slashes."""
     # Import the class instead of the standalone variable
     from fortls.regex_patterns import FortranRegularExpressions
-    
+
     # The exact string that was failing for the user
     test_string = '#include "petsc/finclude/petscvec.h"'
-    
+
     # Call the regex pattern through the class
     match = FortranRegularExpressions.PP_INCLUDE.match(test_string)
-    
+
     # Assert that it found a match
     assert match is not None
-    
+
     # Assert that the captured group contains the full path with slashes
     assert match.group(1) == '"petsc/finclude/petscvec.h"'

--- a/test/test_regex_patterns.py
+++ b/test/test_regex_patterns.py
@@ -44,3 +44,22 @@ def test_src_file_exts(
     regex = create_src_file_exts_regex(input_exts)
     results = [bool(regex.search(file)) for file in input_files]
     assert results == matches
+
+
+
+def test_issue_481_include_with_slashes():
+    """Test that preprocessor includes correctly capture directory slashes."""
+    # Import the class instead of the standalone variable
+    from fortls.regex_patterns import FortranRegularExpressions
+    
+    # The exact string that was failing for the user
+    test_string = '#include "petsc/finclude/petscvec.h"'
+    
+    # Call the regex pattern through the class
+    match = FortranRegularExpressions.PP_INCLUDE.match(test_string)
+    
+    # Assert that it found a match
+    assert match is not None
+    
+    # Assert that the captured group contains the full path with slashes
+    assert match.group(1) == '"petsc/finclude/petscvec.h"'


### PR DESCRIPTION
### Description
This PR resolves #481 where the `PP_INCLUDE` regular expression failed to capture file paths containing directory slashes, causing the language server to miss include files in subdirectories. 

### Changes Made
* Updated the capture group in `fortls/regex_patterns.py` to `[\"\w\./\\]*` so it properly parses both forward (`/`) and backward (`\`) slashes in paths.
* Added a unit test in `test/test_regex_patterns.py` using the exact string from the issue report (`#include "petsc/finclude/petscvec.h"`) to ensure the regex successfully extracts the full path.

### Additional Context
*I am a prospective GSoC 2026 contributor and am submitting this patch as part of my application process. I am looking forward to any feedback!*